### PR TITLE
Add GetWorkflowResult to client

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -8,6 +8,13 @@ import (
 	"github.com/cschleiden/go-workflows/workflow"
 )
 
+type WorkflowState int
+
+const (
+	WorkflowStateActive WorkflowState = iota
+	WorkflowStateFinished
+)
+
 //go:generate mockery --name=Backend --inpackage
 type Backend interface {
 	// CreateWorkflowInstance creates a new workflow instance
@@ -15,6 +22,12 @@ type Backend interface {
 
 	// CancelWorkflowInstance cancels a running workflow instance
 	CancelWorkflowInstance(ctx context.Context, instance workflow.Instance) error
+
+	// GetWorkflowInstanceState returns the state of the given workflow instance
+	GetWorkflowInstanceState(ctx context.Context, instance workflow.Instance) (WorkflowState, error)
+
+	// GetWorkflowInstanceHistory returns the full workflow history for the given instance
+	GetWorkflowInstanceHistory(ctx context.Context, instance workflow.Instance) ([]history.Event, error)
 
 	// SignalWorkflow signals a running workflow instance
 	SignalWorkflow(ctx context.Context, instanceID string, event history.Event) error

--- a/backend/mock_Backend.go
+++ b/backend/mock_Backend.go
@@ -125,6 +125,50 @@ func (_m *MockBackend) GetActivityTask(ctx context.Context) (*task.Activity, err
 	return r0, r1
 }
 
+// GetWorkflowInstanceHistory provides a mock function with given fields: ctx, instance
+func (_m *MockBackend) GetWorkflowInstanceHistory(ctx context.Context, instance core.WorkflowInstance) ([]history.Event, error) {
+	ret := _m.Called(ctx, instance)
+
+	var r0 []history.Event
+	if rf, ok := ret.Get(0).(func(context.Context, core.WorkflowInstance) []history.Event); ok {
+		r0 = rf(ctx, instance)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]history.Event)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, core.WorkflowInstance) error); ok {
+		r1 = rf(ctx, instance)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetWorkflowInstanceState provides a mock function with given fields: ctx, instance
+func (_m *MockBackend) GetWorkflowInstanceState(ctx context.Context, instance core.WorkflowInstance) (WorkflowState, error) {
+	ret := _m.Called(ctx, instance)
+
+	var r0 WorkflowState
+	if rf, ok := ret.Get(0).(func(context.Context, core.WorkflowInstance) WorkflowState); ok {
+		r0 = rf(ctx, instance)
+	} else {
+		r0 = ret.Get(0).(WorkflowState)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, core.WorkflowInstance) error); ok {
+		r1 = rf(ctx, instance)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetWorkflowTask provides a mock function with given fields: ctx
 func (_m *MockBackend) GetWorkflowTask(ctx context.Context) (*task.Workflow, error) {
 	ret := _m.Called(ctx)

--- a/backend/sqlite/schema.sql
+++ b/backend/sqlite/schema.sql
@@ -8,7 +8,6 @@ CREATE TABLE IF NOT EXISTS `instances` (
   `locked_until` DATETIME NULL,
   `sticky_until` DATETIME NULL,
   `worker` TEXT NULL
-
 );
 
 CREATE INDEX IF NOT EXISTS `idx_instances_locked_until_completed_at` ON `instances` (`locked_until`, `sticky_until`, `completed_at`, `worker`);

--- a/client/client.go
+++ b/client/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/cschleiden/go-workflows/backend"
 	a "github.com/cschleiden/go-workflows/internal/args"
 	"github.com/cschleiden/go-workflows/internal/converter"
@@ -15,6 +16,9 @@ import (
 	"github.com/pkg/errors"
 )
 
+var ErrWorkflowCanceled = errors.New("workflow canceled")
+var ErrWorkflowTerminated = errors.New("workflow terminated")
+
 type WorkflowInstanceOptions struct {
 	InstanceID string
 }
@@ -24,16 +28,20 @@ type Client interface {
 
 	CancelWorkflowInstance(ctx context.Context, instance workflow.Instance) error
 
+	WaitForWorkflowInstance(ctx context.Context, instance workflow.Instance, timeout time.Duration) error
+
 	SignalWorkflow(ctx context.Context, instanceID string, name string, arg interface{}) error
 }
 
 type client struct {
 	backend backend.Backend
+	clock   clock.Clock
 }
 
 func New(backend backend.Backend) Client {
 	return &client{
 		backend: backend,
+		clock:   clock.New(),
 	}
 }
 
@@ -44,7 +52,7 @@ func (c *client) CreateWorkflowInstance(ctx context.Context, options WorkflowIns
 	}
 
 	startedEvent := history.NewHistoryEvent(
-		time.Now(),
+		c.clock.Now(),
 		history.EventType_WorkflowExecutionStarted,
 		&history.ExecutionStartedAttributes{
 			Name:   fn.Name(wf),
@@ -76,7 +84,7 @@ func (c *client) SignalWorkflow(ctx context.Context, instanceID string, name str
 	}
 
 	event := history.NewHistoryEvent(
-		time.Now(),
+		c.clock.Now(),
 		history.EventType_SignalReceived,
 		&history.SignalReceivedAttributes{
 			Name: name,
@@ -85,4 +93,80 @@ func (c *client) SignalWorkflow(ctx context.Context, instanceID string, name str
 	)
 
 	return c.backend.SignalWorkflow(ctx, instanceID, event)
+}
+
+func (c *client) WaitForWorkflowInstance(ctx context.Context, instance workflow.Instance, timeout time.Duration) error {
+	if timeout == 0 {
+		timeout = time.Second * 20
+	}
+
+	ticker := c.clock.Ticker(time.Second)
+	defer ticker.Stop()
+
+	ctx, cancel := c.clock.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	for {
+		s, err := c.backend.GetWorkflowInstanceState(ctx, instance)
+		if err != nil {
+			return errors.Wrap(err, "could not get workflow state")
+		}
+
+		if s == backend.WorkflowStateFinished {
+			return nil
+		}
+
+		ticker.Reset(time.Second)
+		select {
+		case <-ticker.C:
+			continue
+
+		case <-ctx.Done():
+			return errors.New("workflow did not finish in specified timeout")
+		}
+	}
+}
+
+func GetWorkflowResult[T any](ctx context.Context, c Client, instance workflow.Instance, timeout time.Duration) (T, error) {
+	// Zero result
+	var z T
+
+	if err := c.WaitForWorkflowInstance(ctx, instance, timeout); err != nil {
+		return z, errors.Wrap(err, "workflow did not finish in time")
+	}
+
+	ic := c.(*client)
+	b := ic.backend
+
+	h, err := b.GetWorkflowInstanceHistory(ctx, instance)
+	if err != nil {
+		return z, errors.Wrap(err, "could not get workflow history")
+	}
+
+	// Iterate over history backwards
+	for i := len(h) - 1; i >= 0; i-- {
+		event := h[i]
+		switch event.Type {
+		case history.EventType_WorkflowExecutionFinished:
+			a := event.Attributes.(*history.ExecutionCompletedAttributes)
+			if a.Error != "" {
+				return z, errors.New(a.Error)
+			}
+
+			var r T
+			if err := converter.DefaultConverter.From(a.Result, &r); err != nil {
+				return z, errors.Wrap(err, "could not convert result")
+			}
+
+			return r, nil
+
+		case history.EventType_WorkflowExecutionCanceled:
+			return z, ErrWorkflowCanceled
+
+		case history.EventType_WorkflowExecutionTerminated:
+			return z, ErrWorkflowTerminated
+		}
+	}
+
+	return z, errors.New("workflow finished, but could not find result event")
 }


### PR DESCRIPTION
`GetWorkflowResult` polls the backend for the history of a workflow, checks
for events indicating workflow completion, and then returns the results
from the event's attributes.

If the workflow has not yet completed, it will wait and then poll again until
the given timeout is reached.

In the future, this should be optimized to only fetch history events of interest,
but for now it just pulls down the full history.