### PR TITLE
Add executor generated sequence ids

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -55,7 +55,7 @@ type Backend interface {
 	// GetActivityTask returns a pending activity task or nil if there are no pending activities
 	GetActivityTask(ctx context.Context) (*task.Activity, error)
 
-	// CompleteActivityTask completes a activity task retrieved using GetActivityTask
+	// CompleteActivityTask completes an activity task retrieved using GetActivityTask
 	CompleteActivityTask(ctx context.Context, instance *workflow.Instance, activityID string, event history.Event) error
 
 	// ExtendActivityTask extends the lock of an activity task

--- a/backend/mysql/events.go
+++ b/backend/mysql/events.go
@@ -25,8 +25,8 @@ func insertEvents(ctx context.Context, tx *sql.Tx, tableName string, instanceID 
 		}
 		batchEvents := events[batchStart:batchEnd]
 
-		query := "INSERT INTO `" + tableName + "` (event_id, instance_id, event_type, timestamp, schedule_event_id, attributes, visible_at) VALUES (?, ?, ?, ?, ?, ?, ?)" +
-			strings.Repeat(", (?, ?, ?, ?, ?, ?, ?)", len(batchEvents)-1)
+		query := "INSERT INTO `" + tableName + "` (event_id, sequence_id, instance_id, event_type, timestamp, schedule_event_id, attributes, visible_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)" +
+			strings.Repeat(", (?, ?, ?, ?, ?, ?, ?, ?)", len(batchEvents)-1)
 
 		args := make([]interface{}, 0, len(batchEvents)*7)
 
@@ -36,7 +36,7 @@ func insertEvents(ctx context.Context, tx *sql.Tx, tableName string, instanceID 
 				return err
 			}
 
-			args = append(args, newEvent.ID, instanceID, newEvent.Type, newEvent.Timestamp, newEvent.ScheduleEventID, a, newEvent.VisibleAt)
+			args = append(args, newEvent.ID, newEvent.SequenceID, instanceID, newEvent.Type, newEvent.Timestamp, newEvent.ScheduleEventID, a, newEvent.VisibleAt)
 		}
 
 		_, err := tx.ExecContext(

--- a/backend/mysql/mysql.go
+++ b/backend/mysql/mysql.go
@@ -200,7 +200,7 @@ func (b *mysqlBackend) GetWorkflowInstanceState(ctx context.Context, instance *w
 
 func createInstance(ctx context.Context, tx *sql.Tx, wfi *workflow.Instance, ignoreDuplicate bool) error {
 	var parentInstanceID *string
-	var parentEventID *int
+	var parentEventID *int64
 	if wfi.SubWorkflow() {
 		i := wfi.ParentInstanceID
 		parentInstanceID = &i
@@ -291,7 +291,7 @@ func (b *mysqlBackend) GetWorkflowTask(ctx context.Context) (*task.Workflow, err
 	var id int
 	var instanceID, executionID string
 	var parentInstanceID *string
-	var parentEventID *int
+	var parentEventID *int64
 	var stickyUntil *time.Time
 	if err := row.Scan(&id, &instanceID, &executionID, &parentInstanceID, &parentEventID, &stickyUntil); err != nil {
 		if err == sql.ErrNoRows {

--- a/backend/mysql/schema.sql
+++ b/backend/mysql/schema.sql
@@ -1,9 +1,9 @@
 CREATE TABLE IF NOT EXISTS `instances` (
-  `id` BIGBIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  `id` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
   `instance_id` NVARCHAR(128) NOT NULL,
   `execution_id` NVARCHAR(128) NOT NULL,
   `parent_instance_id` NVARCHAR(128) NULL,
-  `parent_schedule_event_id` BIGBIGINT NULL,
+  `parent_schedule_event_id` BIGINT NULL,
   `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `completed_at` DATETIME NULL,
   `locked_until` DATETIME NULL,
@@ -19,6 +19,7 @@ CREATE TABLE IF NOT EXISTS `instances` (
 CREATE TABLE IF NOT EXISTS `pending_events` (
   `id` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
   `event_id` NVARCHAR(128) NOT NULL,
+  `sequence_id` BIGINT NOT NULL, -- Not used, but keep for now for query compat
   `instance_id` NVARCHAR(128) NOT NULL,
   `event_type` INT NOT NULL,
   `timestamp` DATETIME NOT NULL,
@@ -34,6 +35,7 @@ CREATE TABLE IF NOT EXISTS `pending_events` (
 CREATE TABLE IF NOT EXISTS `history` (
   `id` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
   `event_id` NVARCHAR(64) NOT NULL,
+  `sequence_id` BIGINT NOT NULL,
   `instance_id` NVARCHAR(128) NOT NULL,
   `event_type` INT NOT NULL,
   `timestamp` DATETIME NOT NULL,

--- a/backend/mysql/schema.sql
+++ b/backend/mysql/schema.sql
@@ -1,9 +1,9 @@
 CREATE TABLE IF NOT EXISTS `instances` (
-  `id` int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  `id` BIGBIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
   `instance_id` NVARCHAR(128) NOT NULL,
   `execution_id` NVARCHAR(128) NOT NULL,
   `parent_instance_id` NVARCHAR(128) NULL,
-  `parent_schedule_event_id` INT NULL,
+  `parent_schedule_event_id` BIGBIGINT NULL,
   `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `completed_at` DATETIME NULL,
   `locked_until` DATETIME NULL,
@@ -17,12 +17,12 @@ CREATE TABLE IF NOT EXISTS `instances` (
 
 
 CREATE TABLE IF NOT EXISTS `pending_events` (
-  `id` int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  `id` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
   `event_id` NVARCHAR(128) NOT NULL,
   `instance_id` NVARCHAR(128) NOT NULL,
   `event_type` INT NOT NULL,
   `timestamp` DATETIME NOT NULL,
-  `schedule_event_id` INT NOT NULL,
+  `schedule_event_id` BIGINT NOT NULL,
   `attributes` BLOB NOT NULL,
   `visible_at` DATETIME NULL,
 
@@ -32,12 +32,12 @@ CREATE TABLE IF NOT EXISTS `pending_events` (
 
 
 CREATE TABLE IF NOT EXISTS `history` (
-  `id` int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  `id` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
   `event_id` NVARCHAR(64) NOT NULL,
   `instance_id` NVARCHAR(128) NOT NULL,
   `event_type` INT NOT NULL,
   `timestamp` DATETIME NOT NULL,
-  `schedule_event_id` INT NOT NULL,
+  `schedule_event_id` BIGINT NOT NULL,
   `attributes` BLOB NOT NULL,
   `visible_at` DATETIME NULL, -- Is this required?
 
@@ -46,13 +46,13 @@ CREATE TABLE IF NOT EXISTS `history` (
 
 
 CREATE TABLE IF NOT EXISTS `activities` (
-  `id` int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  `id` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
   `activity_id` NVARCHAR(64) NOT NULL,
   `instance_id` NVARCHAR(128) NOT NULL,
   `execution_id` NVARCHAR(128) NOT NULL,
   `event_type` INT NOT NULL,
   `timestamp` DATETIME NOT NULL,
-  `schedule_event_id` INT NOT NULL,
+  `schedule_event_id` BIGINT NOT NULL,
   `attributes` BLOB NOT NULL,
   `visible_at` DATETIME NULL,
   `locked_until` DATETIME NULL,

--- a/backend/redis/redis.go
+++ b/backend/redis/redis.go
@@ -1,7 +1,6 @@
 package redis
 
 import (
-	"context"
 	"time"
 
 	"github.com/cschleiden/go-workflows/backend"
@@ -42,10 +41,10 @@ func NewRedisBackend(address, username, password string, db int, opts ...RedisBa
 		DB:       db,
 	})
 
-	// // TODO: Only for dev
-	if err := client.FlushDB(context.Background()).Err(); err != nil {
-		panic(err)
-	}
+	// // // TODO: Only for dev
+	// if err := client.FlushDB(context.Background()).Err(); err != nil {
+	// 	panic(err)
+	// }
 
 	workflowQueue, err := taskqueue.New[workflowTaskData](client, "workflows")
 	if err != nil {

--- a/backend/redis/redis.go
+++ b/backend/redis/redis.go
@@ -1,6 +1,7 @@
 package redis
 
 import (
+	"context"
 	"time"
 
 	"github.com/cschleiden/go-workflows/backend"
@@ -42,9 +43,9 @@ func NewRedisBackend(address, username, password string, db int, opts ...RedisBa
 	})
 
 	// // TODO: Only for dev
-	// if err := client.FlushDB(context.Background()).Err(); err != nil {
-	// 	panic(err)
-	// }
+	if err := client.FlushDB(context.Background()).Err(); err != nil {
+		panic(err)
+	}
 
 	workflowQueue, err := taskqueue.New[workflowTaskData](client, "workflows")
 	if err != nil {

--- a/backend/redis/taskqueue/queue.go
+++ b/backend/redis/taskqueue/queue.go
@@ -152,6 +152,9 @@ func (q *taskQueue[T]) Extend(ctx context.Context, taskID string) error {
 // We have to XACK _and_ XDEL here. See https://github.com/redis/redis/issues/5754
 var completeCmd = redis.NewScript(`
 	local task = redis.call("XRANGE", KEYS[2], ARGV[1], ARGV[1])
+	if task == nil then
+		return nil
+	end
 	local id = task[1][2][2]
 	redis.call("SREM", KEYS[1], id)
 	redis.call("XACK", KEYS[2], ARGV[2], ARGV[1])

--- a/backend/redis/taskqueue/queue_test.go
+++ b/backend/redis/taskqueue/queue_test.go
@@ -23,6 +23,7 @@ func Test_TaskQueue(t *testing.T) {
 	})
 
 	lockTimeout := time.Millisecond * 10
+	blockTimeout := time.Millisecond * 10
 
 	tests := []struct {
 		name string
@@ -45,7 +46,7 @@ func Test_TaskQueue(t *testing.T) {
 				_, err = q.Enqueue(context.Background(), "t1", nil)
 				require.NoError(t, err)
 
-				task, err := q.Dequeue(context.Background(), lockTimeout, time.Millisecond*10)
+				task, err := q.Dequeue(context.Background(), lockTimeout, blockTimeout)
 				require.NoError(t, err)
 				require.NotNil(t, task)
 				require.Equal(t, "t1", task.ID)
@@ -63,7 +64,7 @@ func Test_TaskQueue(t *testing.T) {
 				_, err = q.Enqueue(context.Background(), "t1", nil)
 				require.Error(t, ErrTaskAlreadyInQueue, err)
 
-				task, err := q.Dequeue(context.Background(), lockTimeout, time.Millisecond*10)
+				task, err := q.Dequeue(context.Background(), lockTimeout, blockTimeout)
 				require.NoError(t, err)
 				require.NotNil(t, task)
 
@@ -91,7 +92,7 @@ func Test_TaskQueue(t *testing.T) {
 				})
 				require.NoError(t, err)
 
-				task, err := q.Dequeue(context.Background(), lockTimeout, time.Millisecond*10)
+				task, err := q.Dequeue(context.Background(), lockTimeout, blockTimeout)
 				require.NoError(t, err)
 				require.NotNil(t, task)
 				require.Equal(t, "t1", task.ID)
@@ -111,7 +112,7 @@ func Test_TaskQueue(t *testing.T) {
 				require.NoError(t, err)
 
 				// Dequeue using second worker
-				task, err := q2.Dequeue(context.Background(), lockTimeout, time.Millisecond*10)
+				task, err := q2.Dequeue(context.Background(), lockTimeout, blockTimeout)
 				require.NoError(t, err)
 				require.NotNil(t, task)
 				require.Equal(t, "t1", task.ID)
@@ -126,7 +127,7 @@ func Test_TaskQueue(t *testing.T) {
 				_, err := q.Enqueue(context.Background(), "t1", nil)
 				require.NoError(t, err)
 
-				task, err := q.Dequeue(context.Background(), lockTimeout, time.Millisecond*10)
+				task, err := q.Dequeue(context.Background(), lockTimeout, blockTimeout)
 				require.NoError(t, err)
 				require.NotNil(t, task)
 
@@ -137,7 +138,7 @@ func Test_TaskQueue(t *testing.T) {
 				time.Sleep(time.Millisecond * 10)
 
 				// Try to recover using second worker
-				task2, err := q2.Dequeue(context.Background(), lockTimeout, time.Millisecond*10)
+				task2, err := q2.Dequeue(context.Background(), lockTimeout, blockTimeout)
 				require.NoError(t, err)
 				require.Nil(t, task2)
 			},
@@ -153,7 +154,7 @@ func Test_TaskQueue(t *testing.T) {
 				q2, _ := New[any](client, "test")
 				require.NoError(t, err)
 
-				task, err := q2.Dequeue(context.Background(), lockTimeout, time.Millisecond*10)
+				task, err := q2.Dequeue(context.Background(), lockTimeout, blockTimeout)
 				require.NoError(t, err)
 				require.NotNil(t, task)
 				require.Equal(t, "t1", task.ID)
@@ -161,7 +162,7 @@ func Test_TaskQueue(t *testing.T) {
 				time.Sleep(time.Millisecond * 10)
 
 				// Assume q2 crashed, recover from other worker
-				recoveredTask, err := q.Dequeue(context.Background(), time.Millisecond*1, time.Millisecond*10)
+				recoveredTask, err := q.Dequeue(context.Background(), time.Millisecond*1, blockTimeout)
 				require.NoError(t, err)
 				require.NotNil(t, task)
 				require.Equal(t, task, recoveredTask)
@@ -178,17 +179,17 @@ func Test_TaskQueue(t *testing.T) {
 				q2, _ := New[any](client, "test")
 				require.NoError(t, err)
 
-				task, err := q2.Dequeue(context.Background(), lockTimeout, time.Millisecond*10)
+				task, err := q2.Dequeue(context.Background(), lockTimeout, blockTimeout)
 				require.NoError(t, err)
 				require.NotNil(t, task)
 				require.Equal(t, "t1", task.ID)
 
-				time.Sleep(time.Millisecond * 10)
+				time.Sleep(time.Millisecond * 5)
 
 				err = q2.Extend(context.Background(), task.TaskID)
 				require.NoError(t, err)
 
-				recoveredTask, err := q.Dequeue(context.Background(), lockTimeout, time.Millisecond*10)
+				recoveredTask, err := q.Dequeue(context.Background(), lockTimeout*2, blockTimeout)
 				require.NoError(t, err)
 				require.Nil(t, recoveredTask)
 			},

--- a/backend/sqlite/events.go
+++ b/backend/sqlite/events.go
@@ -61,7 +61,7 @@ func scanEvent(row Scanner) (history.Event, error) {
 
 	historyEvent := history.Event{}
 
-	if err := row.Scan(&historyEvent.ID, &instanceID, &historyEvent.Type, &historyEvent.Timestamp, &historyEvent.ScheduleEventID, &attributes, &historyEvent.VisibleAt); err != nil {
+	if err := row.Scan(&historyEvent.ID, &historyEvent.SequenceID, &instanceID, &historyEvent.Type, &historyEvent.Timestamp, &historyEvent.ScheduleEventID, &attributes, &historyEvent.VisibleAt); err != nil {
 		return historyEvent, errors.Wrap(err, "could not scan event")
 	}
 
@@ -92,8 +92,8 @@ func insertEvents(ctx context.Context, tx *sql.Tx, tableName string, instanceID 
 		}
 		batchEvents := events[batchStart:batchEnd]
 
-		query := "INSERT INTO `" + tableName + "` (id, instance_id, event_type, timestamp, schedule_event_id, attributes, visible_at) VALUES (?, ?, ?, ?, ?, ?, ?)" +
-			strings.Repeat(", (?, ?, ?, ?, ?, ?, ?)", len(batchEvents)-1)
+		query := "INSERT INTO `" + tableName + "` (id, sequence_id, instance_id, event_type, timestamp, schedule_event_id, attributes, visible_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)" +
+			strings.Repeat(", (?, ?, ?, ?, ?, ?, ?, ?)", len(batchEvents)-1)
 
 		args := make([]interface{}, 0, len(batchEvents)*7)
 
@@ -103,7 +103,7 @@ func insertEvents(ctx context.Context, tx *sql.Tx, tableName string, instanceID 
 				return err
 			}
 
-			args = append(args, newEvent.ID, instanceID, newEvent.Type, newEvent.Timestamp, newEvent.ScheduleEventID, a, newEvent.VisibleAt)
+			args = append(args, newEvent.ID, newEvent.SequenceID, instanceID, newEvent.Type, newEvent.Timestamp, newEvent.ScheduleEventID, a, newEvent.VisibleAt)
 		}
 
 		_, err := tx.ExecContext(

--- a/backend/sqlite/schema.sql
+++ b/backend/sqlite/schema.sql
@@ -15,6 +15,7 @@ CREATE INDEX IF NOT EXISTS `idx_instances_parent_instance_id` ON `instances` (`p
 
 CREATE TABLE IF NOT EXISTS `pending_events` (
   `id` TEXT PRIMARY KEY,
+  `sequence_id` INTEGER NOT NULL, -- not used but keep for now for query compat
   `instance_id` TEXT NOT NULL,
   `event_type` INTEGER NOT NULL,
   `timestamp` DATETIME NOT NULL,
@@ -23,8 +24,11 @@ CREATE TABLE IF NOT EXISTS `pending_events` (
   `visible_at` DATETIME NULL
 );
 
+CREATE INDEX IF NOT EXISTS `idx_pending_events_instance_id_visible_at` ON `pending_events` (`instance_id`, `visible_at`);
+
 CREATE TABLE IF NOT EXISTS `history` (
   `id` TEXT PRIMARY KEY,
+  `sequence_id` INTEGER NOT NULL,
   `instance_id` TEXT NOT NULL,
   `event_type` INTEGER NOT NULL,
   `timestamp` DATETIME NOT NULL,
@@ -32,6 +36,8 @@ CREATE TABLE IF NOT EXISTS `history` (
   `attributes` BLOB NOT NULL,
   `visible_at` DATETIME NULL
 );
+
+CREATE INDEX IF NOT EXISTS `idx_history_instance_sequence_id` ON `history` (`instance_id`, `sequence_id`);
 
 CREATE TABLE IF NOT EXISTS `activities` (
   `id` TEXT PRIMARY KEY,

--- a/backend/sqlite/sqlite.go
+++ b/backend/sqlite/sqlite.go
@@ -89,7 +89,7 @@ func (sb *sqliteBackend) CreateWorkflowInstance(ctx context.Context, m history.W
 
 func createInstance(ctx context.Context, tx *sql.Tx, wfi *workflow.Instance, ignoreDuplicate bool) error {
 	var parentInstanceID *string
-	var parentEventID *int
+	var parentEventID *int64
 	if wfi.SubWorkflow() {
 		i := wfi.ParentInstanceID
 		parentInstanceID = &i
@@ -257,7 +257,7 @@ func (sb *sqliteBackend) GetWorkflowTask(ctx context.Context) (*task.Workflow, e
 
 	var instanceID, executionID string
 	var parentInstanceID *string
-	var parentEventID *int
+	var parentEventID *int64
 	var stickyUntil *time.Time
 	if err := row.Scan(&instanceID, &executionID, &parentInstanceID, &parentEventID, &stickyUntil); err != nil {
 		if err == sql.ErrNoRows {

--- a/client/client.go
+++ b/client/client.go
@@ -51,7 +51,7 @@ func (c *client) CreateWorkflowInstance(ctx context.Context, options WorkflowIns
 		return nil, errors.Wrap(err, "could not convert arguments")
 	}
 
-	startedEvent := history.NewHistoryEvent(
+	startedEvent := history.NewPendingEvent(
 		c.clock.Now(),
 		history.EventType_WorkflowExecutionStarted,
 		&history.ExecutionStartedAttributes{
@@ -86,7 +86,7 @@ func (c *client) SignalWorkflow(ctx context.Context, instanceID string, name str
 		return errors.Wrap(err, "could not convert arguments")
 	}
 
-	event := history.NewHistoryEvent(
+	signalEvent := history.NewPendingEvent(
 		c.clock.Now(),
 		history.EventType_SignalReceived,
 		&history.SignalReceivedAttributes{
@@ -95,7 +95,7 @@ func (c *client) SignalWorkflow(ctx context.Context, instanceID string, name str
 		},
 	)
 
-	err = c.backend.SignalWorkflow(ctx, instanceID, event)
+	err = c.backend.SignalWorkflow(ctx, instanceID, signalEvent)
 	if err != nil {
 		return err
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -52,8 +52,8 @@ func Test_Client_GetWorkflowResultSuccess(t *testing.T) {
 	})
 	b.On("GetWorkflowInstanceState", mock.Anything, instance).Return(backend.WorkflowStateFinished, nil)
 	b.On("GetWorkflowInstanceHistory", mock.Anything, instance).Return([]history.Event{
-		history.NewHistoryEvent(time.Now(), history.EventType_WorkflowExecutionStarted, &history.ExecutionStartedAttributes{}),
-		history.NewHistoryEvent(time.Now(), history.EventType_WorkflowExecutionFinished, &history.ExecutionCompletedAttributes{
+		history.NewHistoryEvent(1, time.Now(), history.EventType_WorkflowExecutionStarted, &history.ExecutionStartedAttributes{}),
+		history.NewHistoryEvent(2, time.Now(), history.EventType_WorkflowExecutionFinished, &history.ExecutionCompletedAttributes{
 			Result: r,
 			Error:  "",
 		}),

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -35,7 +35,7 @@ const (
 type Command struct {
 	State CommandState
 
-	ID int
+	ID int64
 
 	Type CommandType
 
@@ -47,7 +47,7 @@ type ScheduleActivityTaskCommandAttr struct {
 	Inputs []payload.Payload
 }
 
-func NewScheduleActivityTaskCommand(id int, name string, inputs []payload.Payload) Command {
+func NewScheduleActivityTaskCommand(id int64, name string, inputs []payload.Payload) Command {
 	return Command{
 		ID:   id,
 		Type: CommandType_ScheduleActivityTask,
@@ -64,7 +64,7 @@ type ScheduleSubWorkflowCommandAttr struct {
 	Inputs     []payload.Payload
 }
 
-func NewScheduleSubWorkflowCommand(id int, instanceID, name string, inputs []payload.Payload) Command {
+func NewScheduleSubWorkflowCommand(id int64, instanceID, name string, inputs []payload.Payload) Command {
 	if instanceID == "" {
 		instanceID = uuid.New().String()
 	}
@@ -84,7 +84,7 @@ type ScheduleTimerCommandAttr struct {
 	At time.Time
 }
 
-func NewScheduleTimerCommand(id int, at time.Time) Command {
+func NewScheduleTimerCommand(id int64, at time.Time) Command {
 	return Command{
 		ID:   id,
 		Type: CommandType_ScheduleTimer,
@@ -98,7 +98,7 @@ type CancelTimerCommandAttr struct {
 	TimerID int
 }
 
-func NewCancelTimerCommand(id, timerID int) Command {
+func NewCancelTimerCommand(id int64, timerID int) Command {
 	return Command{
 		ID:   id,
 		Type: CommandType_CancelTimer,
@@ -112,7 +112,7 @@ type SideEffectCommandAttr struct {
 	Result payload.Payload
 }
 
-func NewSideEffectCommand(id int, result payload.Payload) Command {
+func NewSideEffectCommand(id int64, result payload.Payload) Command {
 	return Command{
 		ID:   id,
 		Type: CommandType_SideEffect,
@@ -127,7 +127,7 @@ type CompleteWorkflowCommandAttr struct {
 	Error  string
 }
 
-func NewCompleteWorkflowCommand(id int, result payload.Payload, err error) Command {
+func NewCompleteWorkflowCommand(id int64, result payload.Payload, err error) Command {
 	var error string
 	if err != nil {
 		error = err.Error()

--- a/internal/core/instance.go
+++ b/internal/core/instance.go
@@ -5,7 +5,7 @@ type WorkflowInstance struct {
 	ExecutionID string `json:"execution_id,omitempty"`
 
 	ParentInstanceID string `json:"parent_instance,omitempty"`
-	ParentEventID    int    `json:"parent_event_id,omitempty"`
+	ParentEventID    int64  `json:"parent_event_id,omitempty"`
 }
 
 func NewWorkflowInstance(instanceID, executionID string) *WorkflowInstance {
@@ -15,7 +15,7 @@ func NewWorkflowInstance(instanceID, executionID string) *WorkflowInstance {
 	}
 }
 
-func NewSubWorkflowInstance(instanceID, executionID string, parentInstanceID string, parentEventID int) *WorkflowInstance {
+func NewSubWorkflowInstance(instanceID, executionID string, parentInstanceID string, parentEventID int64) *WorkflowInstance {
 	return &WorkflowInstance{
 		InstanceID:       instanceID,
 		ExecutionID:      executionID,

--- a/internal/history/history.go
+++ b/internal/history/history.go
@@ -85,11 +85,13 @@ type Event struct {
 	// ID is a unique identifier for this event
 	ID string
 
+	// SequenceID is a monotonically increasing sequence number this event. It's only set for events that have
+	// been executed and are in the history
+	SequenceID int64
+
 	Type EventType
 
 	Timestamp time.Time
-
-	SequenceID int64
 
 	// ScheduleEventID is used to correlate events belonging together
 	// For example, if an activity is scheduled, ScheduleEventID of the schedule event and the
@@ -120,9 +122,10 @@ func VisibleAt(visibleAt time.Time) HistoryEventOption {
 	}
 }
 
-func NewHistoryEvent(timestamp time.Time, eventType EventType, attributes interface{}, opts ...HistoryEventOption) Event {
+func NewHistoryEvent(sequenceID int64, timestamp time.Time, eventType EventType, attributes interface{}, opts ...HistoryEventOption) Event {
 	e := Event{
 		ID:         uuid.NewString(),
+		SequenceID: sequenceID,
 		Type:       eventType,
 		Timestamp:  timestamp,
 		Attributes: attributes,
@@ -135,6 +138,10 @@ func NewHistoryEvent(timestamp time.Time, eventType EventType, attributes interf
 	return e
 }
 
+func NewPendingEvent(timestamp time.Time, eventType EventType, attributes interface{}, opts ...HistoryEventOption) Event {
+	return NewHistoryEvent(0, timestamp, eventType, attributes, opts...)
+}
+
 func NewWorkflowCancellationEvent(timestamp time.Time) Event {
-	return NewHistoryEvent(timestamp, EventType_WorkflowExecutionCanceled, &ExecutionCanceledAttributes{})
+	return NewPendingEvent(timestamp, EventType_WorkflowExecutionCanceled, &ExecutionCanceledAttributes{})
 }

--- a/internal/history/history.go
+++ b/internal/history/history.go
@@ -46,28 +46,34 @@ func (et EventType) String() string {
 		return "WorkflowExecutionTerminated"
 	case EventType_WorkflowExecutionCanceled:
 		return "WorkflowExecutionCanceled"
+
 	case EventType_WorkflowTaskStarted:
 		return "WorkflowTaskStarted"
 	case EventType_WorkflowTaskFinished:
 		return "WorkflowTaskFinished"
+
 	case EventType_SubWorkflowScheduled:
 		return "SubWorkflowScheduled"
 	case EventType_SubWorkflowCompleted:
 		return "SubWorkflowCompleted"
 	case EventType_SubWorkflowFailed:
 		return "SubWorkflowFailed"
+
 	case EventType_ActivityScheduled:
 		return "ActivityScheduled"
 	case EventType_ActivityCompleted:
 		return "ActivityCompleted"
 	case EventType_ActivityFailed:
 		return "ActivityFailed"
+
 	case EventType_TimerScheduled:
 		return "TimerScheduled"
 	case EventType_TimerFired:
 		return "TimerFired"
+
 	case EventType_SignalReceived:
 		return "SignalReceived"
+
 	case EventType_SideEffectResult:
 		return "SideEffectResult"
 	default:
@@ -83,10 +89,12 @@ type Event struct {
 
 	Timestamp time.Time
 
+	SequenceID int64
+
 	// ScheduleEventID is used to correlate events belonging together
 	// For example, if an activity is scheduled, ScheduleEventID of the schedule event and the
 	// completion/failure event are the same.
-	ScheduleEventID int
+	ScheduleEventID int64
 
 	// Attributes are event type specific attributes
 	Attributes interface{}
@@ -100,7 +108,7 @@ func (e Event) String() string {
 
 type HistoryEventOption func(e *Event)
 
-func ScheduleEventID(scheduleEventID int) HistoryEventOption {
+func ScheduleEventID(scheduleEventID int64) HistoryEventOption {
 	return func(e *Event) {
 		e.ScheduleEventID = scheduleEventID
 	}

--- a/internal/history/serialization_test.go
+++ b/internal/history/serialization_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestRoundtripJSON(t *testing.T) {
-	event := NewHistoryEvent(time.Now(), EventType_WorkflowExecutionStarted, &ExecutionStartedAttributes{
+	event := NewHistoryEvent(42, time.Now(), EventType_WorkflowExecutionStarted, &ExecutionStartedAttributes{
 		Name: "my-workflow",
 	})
 
@@ -21,6 +21,7 @@ func TestRoundtripJSON(t *testing.T) {
 	require.NoError(t, uerr)
 
 	require.Equal(t, event.ID, event2.ID)
+	require.Equal(t, event.SequenceID, event2.SequenceID)
 	require.Equal(t, event.Type, event2.Type)
 	require.Equal(t, event.VisibleAt, event2.VisibleAt)
 	require.Equal(t, event.Attributes, event2.Attributes)

--- a/internal/tester/tester.go
+++ b/internal/tester/tester.go
@@ -242,9 +242,9 @@ func (wt *workflowTester) Execute(args ...interface{}) {
 			e.Close()
 
 			// Add all executed events to history
-			tw.history = append(tw.history, result.NewEvents...)
+			tw.history = append(tw.history, result.Executed...)
 
-			for _, event := range result.NewEvents {
+			for _, event := range result.Executed {
 				wt.logger.Debug("Event", "event_type", event.Type)
 
 				switch event.Type {
@@ -358,7 +358,7 @@ func (wt *workflowTester) SignalWorkflowInstance(wfi *core.WorkflowInstance, nam
 	}
 
 	wt.callbacks <- func() *history.WorkflowEvent {
-		e := history.NewHistoryEvent(
+		e := history.NewPendingEvent(
 			wt.clock.Now(),
 			history.EventType_SignalReceived,
 			&history.SignalReceivedAttributes{
@@ -464,7 +464,7 @@ func (wt *workflowTester) scheduleActivity(wfi *core.WorkflowInstance, event his
 			var ne history.Event
 
 			if activityErr != nil {
-				ne = history.NewHistoryEvent(
+				ne = history.NewPendingEvent(
 					wt.clock.Now(),
 					history.EventType_ActivityFailed,
 					&history.ActivityFailedAttributes{
@@ -473,7 +473,7 @@ func (wt *workflowTester) scheduleActivity(wfi *core.WorkflowInstance, event his
 					history.ScheduleEventID(event.ScheduleEventID),
 				)
 			} else {
-				ne = history.NewHistoryEvent(
+				ne = history.NewPendingEvent(
 					wt.clock.Now(),
 					history.EventType_ActivityCompleted,
 					&history.ActivityCompletedAttributes{
@@ -571,7 +571,7 @@ func (wt *workflowTester) scheduleSubWorkflow(event history.WorkflowEvent) {
 		var he history.Event
 
 		if workflowErr != nil {
-			he = history.NewHistoryEvent(
+			he = history.NewPendingEvent(
 				wt.clock.Now(),
 				history.EventType_SubWorkflowFailed,
 				&history.SubWorkflowFailedAttributes{
@@ -580,7 +580,7 @@ func (wt *workflowTester) scheduleSubWorkflow(event history.WorkflowEvent) {
 				history.ScheduleEventID(event.WorkflowInstance.ParentEventID),
 			)
 		} else {
-			he = history.NewHistoryEvent(
+			he = history.NewPendingEvent(
 				wt.clock.Now(),
 				history.EventType_SubWorkflowCompleted,
 				&history.SubWorkflowCompletedAttributes{
@@ -606,6 +606,7 @@ func (wt *workflowTester) getInitialEvent(wf interface{}, args []interface{}) hi
 	}
 
 	return history.NewHistoryEvent(
+		1,
 		wt.clock.Now(),
 		history.EventType_WorkflowExecutionStarted,
 		&history.ExecutionStartedAttributes{

--- a/internal/worker/activity.go
+++ b/internal/worker/activity.go
@@ -140,7 +140,7 @@ func (aw *activityWorker) handleTask(ctx context.Context, task *task.Activity) {
 	var event history.Event
 
 	if err != nil {
-		event = history.NewHistoryEvent(
+		event = history.NewPendingEvent(
 			aw.clock.Now(),
 			history.EventType_ActivityFailed,
 			&history.ActivityFailedAttributes{
@@ -149,7 +149,7 @@ func (aw *activityWorker) handleTask(ctx context.Context, task *task.Activity) {
 			history.ScheduleEventID(task.Event.ScheduleEventID),
 		)
 	} else {
-		event = history.NewHistoryEvent(
+		event = history.NewPendingEvent(
 			aw.clock.Now(),
 			history.EventType_ActivityCompleted,
 			&history.ActivityCompletedAttributes{

--- a/internal/worker/workflow.go
+++ b/internal/worker/workflow.go
@@ -129,7 +129,7 @@ func (ww *workflowWorker) handle(ctx context.Context, t *task.Workflow) {
 	}
 
 	if err := ww.backend.CompleteWorkflowTask(
-		ctx, t.ID, t.WorkflowInstance, state, result.NewEvents, result.ActivityEvents, result.WorkflowEvents); err != nil {
+		ctx, t.ID, t.WorkflowInstance, state, result.Executed, result.ActivityEvents, result.WorkflowEvents); err != nil {
 		ww.logger.Panic(err)
 	}
 }

--- a/internal/workflow/executor_test.go
+++ b/internal/workflow/executor_test.go
@@ -61,6 +61,7 @@ func Test_ExecuteWorkflow(t *testing.T) {
 		WorkflowInstance: core.NewWorkflowInstance("instanceID", "executionID"),
 		History: []history.Event{
 			history.NewHistoryEvent(
+				1,
 				time.Now(),
 				history.EventType_WorkflowExecutionStarted,
 				&history.ExecutionStartedAttributes{
@@ -114,6 +115,7 @@ func Test_ReplayWorkflowWithActivityResult(t *testing.T) {
 		WorkflowInstance: core.NewWorkflowInstance("instanceID", "executionID"),
 		History: []history.Event{
 			history.NewHistoryEvent(
+				1,
 				time.Now(),
 				history.EventType_WorkflowExecutionStarted,
 				&history.ExecutionStartedAttributes{
@@ -122,6 +124,7 @@ func Test_ReplayWorkflowWithActivityResult(t *testing.T) {
 				},
 			),
 			history.NewHistoryEvent(
+				2,
 				time.Now(),
 				history.EventType_ActivityScheduled,
 				&history.ActivityScheduledAttributes{
@@ -131,6 +134,7 @@ func Test_ReplayWorkflowWithActivityResult(t *testing.T) {
 				history.ScheduleEventID(1),
 			),
 			history.NewHistoryEvent(
+				3,
 				time.Now(),
 				history.EventType_ActivityCompleted,
 				&history.ActivityCompletedAttributes{
@@ -164,6 +168,7 @@ func Test_ExecuteWorkflowWithActivityCommand(t *testing.T) {
 		WorkflowInstance: core.NewWorkflowInstance("instanceID", "executionID"),
 		History: []history.Event{
 			history.NewHistoryEvent(
+				1,
 				time.Now(),
 				history.EventType_WorkflowExecutionStarted,
 				&history.ExecutionStartedAttributes{
@@ -219,6 +224,7 @@ func Test_ExecuteWorkflowWithTimer(t *testing.T) {
 		WorkflowInstance: core.NewWorkflowInstance("instanceID", "executionID"),
 		History: []history.Event{
 			history.NewHistoryEvent(
+				1,
 				time.Now(),
 				history.EventType_WorkflowExecutionStarted,
 				&history.ExecutionStartedAttributes{
@@ -236,7 +242,7 @@ func Test_ExecuteWorkflowWithTimer(t *testing.T) {
 	require.Equal(t, 1, workflowTimerHits)
 	require.Len(t, e.workflowState.Commands(), 1)
 
-	require.Equal(t, 1, e.workflowState.Commands()[0].ID)
+	require.Equal(t, int64(1), e.workflowState.Commands()[0].ID)
 	require.Equal(t, command.CommandType_ScheduleTimer, e.workflowState.Commands()[0].Type)
 }
 
@@ -274,6 +280,7 @@ func Test_ExecuteWorkflowWithSelector(t *testing.T) {
 		WorkflowInstance: core.NewWorkflowInstance("instanceID", "executionID"),
 		History: []history.Event{
 			history.NewHistoryEvent(
+				1,
 				time.Now(),
 				history.EventType_WorkflowExecutionStarted,
 				&history.ExecutionStartedAttributes{
@@ -312,6 +319,7 @@ func Test_ExecuteNewEvents(t *testing.T) {
 		History:          []history.Event{},
 		NewEvents: []history.Event{
 			history.NewHistoryEvent(
+				1,
 				time.Now(),
 				history.EventType_WorkflowExecutionStarted,
 				&history.ExecutionStartedAttributes{
@@ -320,6 +328,7 @@ func Test_ExecuteNewEvents(t *testing.T) {
 				},
 			),
 			history.NewHistoryEvent(
+				2,
 				time.Now(),
 				history.EventType_ActivityScheduled,
 				&history.ActivityScheduledAttributes{
@@ -342,7 +351,7 @@ func Test_ExecuteNewEvents(t *testing.T) {
 
 	h := []history.Event{}
 	h = append(h, oldTask.NewEvents...)
-	h = append(h, taskResult.NewEvents...)
+	h = append(h, taskResult.Executed...)
 
 	newTask := &task.Workflow{
 		ID:               "taskID",
@@ -350,6 +359,7 @@ func Test_ExecuteNewEvents(t *testing.T) {
 		History:          h,
 		NewEvents: []history.Event{
 			history.NewHistoryEvent(
+				1,
 				time.Now(),
 				history.EventType_ActivityCompleted,
 				&history.ActivityCompletedAttributes{
@@ -394,6 +404,7 @@ func Test_ExecuteWorkflowWithSignal(t *testing.T) {
 		WorkflowInstance: core.NewWorkflowInstance("instanceID", "executionID"),
 		History: []history.Event{
 			history.NewHistoryEvent(
+				1,
 				time.Now(),
 				history.EventType_WorkflowExecutionStarted,
 				&history.ExecutionStartedAttributes{
@@ -402,6 +413,7 @@ func Test_ExecuteWorkflowWithSignal(t *testing.T) {
 				},
 			),
 			history.NewHistoryEvent(
+				2,
 				time.Now(),
 				history.EventType_SignalReceived,
 				&history.SignalReceivedAttributes{

--- a/samples/subworkflow/subworkflow.go
+++ b/samples/subworkflow/subworkflow.go
@@ -7,7 +7,7 @@ import (
 	"os/signal"
 
 	"github.com/cschleiden/go-workflows/backend"
-	"github.com/cschleiden/go-workflows/backend/redis"
+	"github.com/cschleiden/go-workflows/backend/mysql"
 	"github.com/cschleiden/go-workflows/client"
 	"github.com/cschleiden/go-workflows/worker"
 	"github.com/cschleiden/go-workflows/workflow"
@@ -20,10 +20,11 @@ func main() {
 
 	// b := sqlite.NewInMemoryBackend()
 	// b := sqlite.NewSqliteBackend("subworkflow.sqlite")
-	b, err := redis.NewRedisBackend("localhost:6379", "", "RedisPassw0rd", 0)
-	if err != nil {
-		panic(err)
-	}
+	b := mysql.NewMysqlBackend("localhost", 3306, "root", "root", "simple")
+	// b, err := redis.NewRedisBackend("localhost:6379", "", "RedisPassw0rd", 0)
+	// if err != nil {
+	// 	panic(err)
+	// }
 
 	// Run worker
 	go RunWorker(ctx, b)


### PR DESCRIPTION
This is in preparation for making the continuation logic less dependent on the backend and to allow the executor to pull in the history.

This will also enable some cleanup in the mysql and sqlite backends, but that will be a follow up change.