### PR TITLE
Remove continuation task

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -31,8 +31,9 @@ type Backend interface {
 	// GetWorkflowInstanceState returns the state of the given workflow instance
 	GetWorkflowInstanceState(ctx context.Context, instance *workflow.Instance) (WorkflowState, error)
 
-	// GetWorkflowInstanceHistory returns the full workflow history for the given instance
-	GetWorkflowInstanceHistory(ctx context.Context, instance *workflow.Instance) ([]history.Event, error)
+	// GetWorkflowInstanceHistory returns the workflow history for the given instance. When lastSequenceID
+	// is given, only events after that event are returned. Otherwise the full history is returned.
+	GetWorkflowInstanceHistory(ctx context.Context, instance *workflow.Instance, lastSequenceID *int64) ([]history.Event, error)
 
 	// SignalWorkflow signals a running workflow instance
 	SignalWorkflow(ctx context.Context, instanceID string, event history.Event) error

--- a/backend/mock_Backend.go
+++ b/backend/mock_Backend.go
@@ -128,12 +128,12 @@ func (_m *MockBackend) GetActivityTask(ctx context.Context) (*task.Activity, err
 }
 
 // GetWorkflowInstanceHistory provides a mock function with given fields: ctx, instance
-func (_m *MockBackend) GetWorkflowInstanceHistory(ctx context.Context, instance *core.WorkflowInstance) ([]history.Event, error) {
+func (_m *MockBackend) GetWorkflowInstanceHistory(ctx context.Context, instance *core.WorkflowInstance, lastSequenceID *int64) ([]history.Event, error) {
 	ret := _m.Called(ctx, instance)
 
 	var r0 []history.Event
-	if rf, ok := ret.Get(0).(func(context.Context, *core.WorkflowInstance) []history.Event); ok {
-		r0 = rf(ctx, instance)
+	if rf, ok := ret.Get(0).(func(context.Context, *core.WorkflowInstance, *int64) []history.Event); ok {
+		r0 = rf(ctx, instance, lastSequenceID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]history.Event)
@@ -141,8 +141,8 @@ func (_m *MockBackend) GetWorkflowInstanceHistory(ctx context.Context, instance 
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, *core.WorkflowInstance) error); ok {
-		r1 = rf(ctx, instance)
+	if rf, ok := ret.Get(1).(func(context.Context, *core.WorkflowInstance, *int64) error); ok {
+		r1 = rf(ctx, instance, lastSequenceID)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/backend/redis/instance.go
+++ b/backend/redis/instance.go
@@ -49,7 +49,7 @@ func (rb *redisBackend) CreateWorkflowInstance(ctx context.Context, event histor
 	return nil
 }
 
-func (rb *redisBackend) GetWorkflowInstanceHistory(ctx context.Context, instance *core.WorkflowInstance) ([]history.Event, error) {
+func (rb *redisBackend) GetWorkflowInstanceHistory(ctx context.Context, instance *core.WorkflowInstance, lastSequenceID *int64) ([]history.Event, error) {
 	msgs, err := rb.rdb.XRange(ctx, historyKey(instance.InstanceID), "-", "+").Result()
 	if err != nil {
 		return nil, err
@@ -103,10 +103,11 @@ func (rb *redisBackend) CancelWorkflowInstance(ctx context.Context, instance *co
 }
 
 type instanceState struct {
-	Instance    *core.WorkflowInstance `json:"instance,omitempty"`
-	State       backend.WorkflowState  `json:"state,omitempty"`
-	CreatedAt   time.Time              `json:"created_at,omitempty"`
-	CompletedAt *time.Time             `json:"completed_at,omitempty"`
+	Instance       *core.WorkflowInstance `json:"instance,omitempty"`
+	State          backend.WorkflowState  `json:"state,omitempty"`
+	CreatedAt      time.Time              `json:"created_at,omitempty"`
+	CompletedAt    *time.Time             `json:"completed_at,omitempty"`
+	LastSequenceID int64                  `json:"last_sequence_id,omitempty"`
 }
 
 func createInstance(ctx context.Context, rdb redis.UniversalClient, instance *core.WorkflowInstance, ignoreDuplicate bool) error {

--- a/backend/redis/redis.go
+++ b/backend/redis/redis.go
@@ -1,6 +1,7 @@
 package redis
 
 import (
+	"context"
 	"time"
 
 	"github.com/cschleiden/go-workflows/backend"
@@ -43,9 +44,9 @@ func NewRedisBackend(address, username, password string, db int, opts ...RedisBa
 	})
 
 	// // // TODO: Only for dev
-	// if err := client.FlushDB(context.Background()).Err(); err != nil {
-	// 	panic(err)
-	// }
+	if err := client.FlushDB(context.Background()).Err(); err != nil {
+		panic(err)
+	}
 
 	workflowQueue, err := taskqueue.New[workflowTaskData](client, "workflows")
 	if err != nil {

--- a/backend/sqlite/events.go
+++ b/backend/sqlite/events.go
@@ -31,8 +31,14 @@ func getPendingEvents(ctx context.Context, tx *sql.Tx, instanceID string) ([]his
 	return pendingEvents, nil
 }
 
-func getHistory(ctx context.Context, tx *sql.Tx, instanceID string) ([]history.Event, error) {
-	historyEvents, err := tx.QueryContext(ctx, "SELECT * FROM `history` WHERE instance_id = ?", instanceID)
+func getHistory(ctx context.Context, tx *sql.Tx, instanceID string, lastSequenceID *int64) ([]history.Event, error) {
+	var historyEvents *sql.Rows
+	var err error
+	if lastSequenceID != nil {
+		historyEvents, err = tx.QueryContext(ctx, "SELECT * FROM `history` WHERE instance_id = ? AND sequence_id > ?", instanceID, *lastSequenceID)
+	} else {
+		historyEvents, err = tx.QueryContext(ctx, "SELECT * FROM `history` WHERE instance_id = ?", instanceID)
+	}
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get history")
 	}

--- a/backend/test/backendtest.go
+++ b/backend/test/backendtest.go
@@ -168,7 +168,7 @@ func BackendTest(t *testing.T, setup func() backend.Backend, teardown func(b bac
 
 				time.Sleep(time.Second)
 
-				h, err := b.GetWorkflowInstanceHistory(ctx, wfi)
+				h, err := b.GetWorkflowInstanceHistory(ctx, wfi, nil)
 				require.NoError(t, err)
 				require.Equal(t, len(events), len(h))
 				for i, event := range events {

--- a/client/client.go
+++ b/client/client.go
@@ -148,7 +148,7 @@ func GetWorkflowResult[T any](ctx context.Context, c Client, instance *workflow.
 	ic := c.(*client)
 	b := ic.backend
 
-	h, err := b.GetWorkflowInstanceHistory(ctx, instance)
+	h, err := b.GetWorkflowInstanceHistory(ctx, instance, nil)
 	if err != nil {
 		return z, errors.Wrap(err, "could not get workflow history")
 	}

--- a/internal/task/workflow.go
+++ b/internal/task/workflow.go
@@ -5,13 +5,6 @@ import (
 	"github.com/cschleiden/go-workflows/internal/history"
 )
 
-type Kind int
-
-const (
-	_ Kind = iota
-	Continuation
-)
-
 type Workflow struct {
 	// ID is an identifier for this task. It's set by the backend
 	ID string
@@ -19,12 +12,8 @@ type Workflow struct {
 	// WorkflowInstance is the workflow instance that this task is for
 	WorkflowInstance *core.WorkflowInstance
 
-	// Kind defines what kind of task this is. A Continuation task only contains
-	// new events and not the full history. By default the history is included.
-	Kind Kind
-
-	// History are the events that have been executed so far
-	History []history.Event
+	// LastSequenceID is the sequence ID of the newest event in the workflow instances's history
+	LastSequenceID int64
 
 	// NewEvents are new events since the last task execution
 	NewEvents []history.Event

--- a/internal/workflow/cache.go
+++ b/internal/workflow/cache.go
@@ -51,9 +51,9 @@ func (c *workflowExecutorCache) Store(ctx context.Context, instance *core.Workfl
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	if instance, ok := c.cache[getKey(instance)]; ok {
+	if entry, ok := c.cache[getKey(instance)]; ok && entry.executor != executor {
 		// Close existing executor to prevent leaks
-		instance.executor.Close()
+		entry.executor.Close()
 	}
 
 	c.cache[getKey(instance)] = &workflowExecutorCacheEntry{

--- a/internal/workflow/cache_test.go
+++ b/internal/workflow/cache_test.go
@@ -19,7 +19,7 @@ func Test_Cache_StoreAndGet(t *testing.T) {
 
 	r := NewRegistry()
 	r.RegisterWorkflow(workflowWithActivity)
-	e, err := NewExecutor(logger.NewDefaultLogger(), r, i, clock.New())
+	e, err := NewExecutor(logger.NewDefaultLogger(), r, &testHistoryProvider{}, i, clock.New())
 	require.NoError(t, err)
 
 	err = c.Store(context.Background(), i, e)
@@ -40,7 +40,7 @@ func Test_Cache_Evic(t *testing.T) {
 	i := core.NewWorkflowInstance("instanceID", "executionID")
 	r := NewRegistry()
 	r.RegisterWorkflow(workflowWithActivity)
-	e, err := NewExecutor(logger.NewDefaultLogger(), r, i, clock.New())
+	e, err := NewExecutor(logger.NewDefaultLogger(), r, &testHistoryProvider{}, i, clock.New())
 	require.NoError(t, err)
 
 	err = c.Store(context.Background(), i, e)

--- a/internal/workflow/workflow.go
+++ b/internal/workflow/workflow.go
@@ -58,6 +58,11 @@ func (w *workflow) Execute(ctx sync.Context, inputs []payload.Payload) error {
 			if err != nil {
 				return errors.Wrap(err, "could not convert workflow result")
 			}
+		} else {
+			result, err = converter.DefaultConverter.To(nil)
+			if err != nil {
+				return errors.Wrap(err, "could not convert workflow result")
+			}
 		}
 
 		errResult := r[len(r)-1]

--- a/samples/scale/starter/main.go
+++ b/samples/scale/starter/main.go
@@ -8,28 +8,42 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/cschleiden/go-workflows/backend"
 	"github.com/cschleiden/go-workflows/backend/mysql"
+	"github.com/cschleiden/go-workflows/backend/redis"
+	"github.com/cschleiden/go-workflows/backend/sqlite"
 	"github.com/cschleiden/go-workflows/client"
 	scale "github.com/cschleiden/go-workflows/samples/scale"
 	"github.com/google/uuid"
 )
 
 var tostart = flag.Int("count", 100, "Number of workflow instances to start")
+var backendType = flag.String("backend", "redis", "backend to use: sqlite, mysql, redis")
 var count int32
 
 func main() {
 	flag.Parse()
 
-	count = int32(*tostart)
-
 	ctx := context.Background()
 
-	//b := sqlite.NewSqliteBackend("../scale.sqlite")
-	b := mysql.NewMysqlBackend("localhost", 3306, "root", "test", "scale")
-	// b, err := redis.NewRedisBackend("localhost:6379", "", "RedisPassw0rd", 0)
-	// if err != nil {
-	// 	panic(err)
-	// }
+	count = int32(*tostart)
+
+	var b backend.Backend
+
+	switch *backendType {
+	case "sqlite":
+		b = sqlite.NewSqliteBackend("../scale.sqlite?_busy_timeout=10000")
+
+	case "mysql":
+		b = mysql.NewMysqlBackend("localhost", 3306, "root", "root", "scale")
+
+	case "redis":
+		var err error
+		b, err = redis.NewRedisBackend("localhost:6379", "", "RedisPassw0rd", 0)
+		if err != nil {
+			panic(err)
+		}
+	}
 
 	// Start workflow via client
 	c := client.New(b)

--- a/samples/simple/simple.go
+++ b/samples/simple/simple.go
@@ -16,8 +16,8 @@ import (
 func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 
-	b := sqlite.NewSqliteBackend("simple.sqlite")
-	//b := sqlite.NewInMemoryBackend()
+	// b := sqlite.NewSqliteBackend("simple.sqlite")
+	b := sqlite.NewInMemoryBackend()
 	//b := mysql.NewMysqlBackend("localhost", 3306, "root", "test", "simple")
 	// b, err := redis.NewRedisBackend("localhost:6379", "", "RedisPassw0rd", 0)
 	// if err != nil {
@@ -57,8 +57,6 @@ func runWorkflow(ctx context.Context, c client.Client) {
 	}
 
 	log.Println("Workflow finished. Result:", result)
-
-	time.Sleep(time.Minute * 5)
 }
 
 func RunWorker(ctx context.Context, mb backend.Backend) worker.Worker {


### PR DESCRIPTION
This replaces continuation tasks with an explicit call to get the history when required.

Closes: #37 