### PR TITLE
Add some simple E2E tests

### DIFF
--- a/backend/redis/redis_test.go
+++ b/backend/redis/redis_test.go
@@ -43,7 +43,6 @@ func createBackend() backend.Backend {
 		panic(err)
 	}
 
-	// Disable sticky workflow behavior for the test execution
 	b, err := NewRedisBackend(address, user, password, 0, WithBlockTimeout(time.Millisecond*2))
 	if err != nil {
 		panic(err)

--- a/backend/redis/redis_test.go
+++ b/backend/redis/redis_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/cschleiden/go-workflows/backend"
 	"github.com/cschleiden/go-workflows/backend/test"
 	"github.com/go-redis/redis/v8"
-	"github.com/stretchr/testify/require"
 )
 
 func Test_RedisBackend(t *testing.T) {
@@ -16,27 +15,39 @@ func Test_RedisBackend(t *testing.T) {
 		t.Skip()
 	}
 
-	test.BackendTest(t, func() backend.Backend {
-		address := "localhost:6379"
-		user := ""
-		password := "RedisPassw0rd"
+	test.BackendTest(t, createBackend, nil)
+}
 
-		// Flush database
-		client := redis.NewUniversalClient(&redis.UniversalOptions{
-			Addrs:    []string{address},
-			Username: user,
-			Password: password,
-			DB:       0,
-		})
+func Test_EndToEndRedisBackend(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
 
-		if err := client.FlushDB(context.Background()).Err(); err != nil {
-			panic(err)
-		}
+	test.EndToEndBackendTest(t, createBackend, nil)
+}
 
-		// Disable sticky workflow behavior for the test execution
-		b, err := NewRedisBackend(address, user, password, 0, WithBlockTimeout(time.Millisecond*2))
-		require.NoError(t, err)
+func createBackend() backend.Backend {
+	address := "localhost:6379"
+	user := ""
+	password := "RedisPassw0rd"
 
-		return b
-	}, nil)
+	// Flush database
+	client := redis.NewUniversalClient(&redis.UniversalOptions{
+		Addrs:    []string{address},
+		Username: user,
+		Password: password,
+		DB:       0,
+	})
+
+	if err := client.FlushDB(context.Background()).Err(); err != nil {
+		panic(err)
+	}
+
+	// Disable sticky workflow behavior for the test execution
+	b, err := NewRedisBackend(address, user, password, 0, WithBlockTimeout(time.Millisecond*2))
+	if err != nil {
+		panic(err)
+	}
+
+	return b
 }

--- a/backend/sqlite/sqlite_test.go
+++ b/backend/sqlite/sqlite_test.go
@@ -13,3 +13,10 @@ func Test_SqliteBackend(t *testing.T) {
 		return NewInMemoryBackend(backend.WithStickyTimeout(0))
 	}, nil)
 }
+
+func Test_EndToEndSqliteBackend(t *testing.T) {
+	test.EndToEndBackendTest(t, func() backend.Backend {
+		// Disable sticky workflow behavior for the test execution
+		return NewInMemoryBackend(backend.WithStickyTimeout(0))
+	}, nil)
+}

--- a/backend/test/e2e.go
+++ b/backend/test/e2e.go
@@ -100,7 +100,7 @@ func register(t *testing.T, ctx context.Context, w worker.Worker, workflows []in
 func runWorkflow(t *testing.T, ctx context.Context, c client.Client, wf interface{}, inputs ...interface{}) *workflow.Instance {
 	instance, err := c.CreateWorkflowInstance(ctx, client.WorkflowInstanceOptions{
 		InstanceID: uuid.NewString(),
-	}, wf, "hello")
+	}, wf, inputs...)
 	require.NoError(t, err)
 
 	return instance

--- a/backend/test/e2e.go
+++ b/backend/test/e2e.go
@@ -1,0 +1,112 @@
+package test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cschleiden/go-workflows/backend"
+	"github.com/cschleiden/go-workflows/client"
+	"github.com/cschleiden/go-workflows/worker"
+	"github.com/cschleiden/go-workflows/workflow"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func EndToEndBackendTest(t *testing.T, setup func() backend.Backend, teardown func(b backend.Backend)) {
+	tests := []struct {
+		name           string
+		workflow       interface{}
+		workflowInputs []interface{}
+		f              func(t *testing.T, ctx context.Context, c client.Client, w worker.Worker)
+	}{
+		{
+			name: "SimpleWorkflow",
+			f: func(t *testing.T, ctx context.Context, c client.Client, w worker.Worker) {
+				wf := func(ctx workflow.Context, msg string) (string, error) {
+					return msg + " world", nil
+				}
+				register(t, ctx, w, []interface{}{wf}, nil)
+
+				output, err := runWorkflowWithResult[string](t, ctx, c, wf, "hello")
+
+				require.Equal(t, "hello world", output)
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "UnregisteredWorkflow",
+			f: func(t *testing.T, ctx context.Context, c client.Client, w worker.Worker) {
+				wf := func(ctx workflow.Context, msg string) (string, error) {
+					return msg + " world", nil
+				}
+				register(t, ctx, w, nil, nil)
+
+				output, err := runWorkflowWithResult[string](t, ctx, c, wf, "hello")
+
+				require.Nil(t, output)
+				require.Error(t, err)
+			},
+		},
+		{
+			name: "UnregisteredActivity",
+			f: func(t *testing.T, ctx context.Context, c client.Client, w worker.Worker) {
+				a := func(context.Context) error { return nil }
+				wf := func(ctx workflow.Context) (int, error) {
+					return workflow.ExecuteActivity[int](ctx, workflow.DefaultActivityOptions, a).Get(ctx)
+				}
+				register(t, ctx, w, nil, []interface{}{wf})
+
+				output, err := runWorkflowWithResult[int](t, ctx, c, wf)
+
+				require.Zero(t, output)
+				require.ErrorContains(t, err, "activity not found")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := setup()
+			ctx := context.Background()
+
+			c := client.New(b)
+			w := worker.New(b, &worker.DefaultWorkerOptions)
+
+			tt.f(t, ctx, c, w)
+
+			w.Stop()
+
+			if teardown != nil {
+				teardown(b)
+			}
+		})
+	}
+}
+
+func register(t *testing.T, ctx context.Context, w worker.Worker, workflows []interface{}, activities []interface{}) {
+	for _, wf := range workflows {
+		require.NoError(t, w.RegisterWorkflow(wf))
+	}
+
+	for _, a := range activities {
+		require.NoError(t, w.RegisterActivity(a))
+	}
+
+	err := w.Start(ctx)
+	require.NoError(t, err)
+}
+
+func runWorkflow(t *testing.T, ctx context.Context, c client.Client, wf interface{}, inputs ...interface{}) *workflow.Instance {
+	instance, err := c.CreateWorkflowInstance(ctx, client.WorkflowInstanceOptions{
+		InstanceID: uuid.NewString(),
+	}, wf, "hello")
+	require.NoError(t, err)
+
+	return instance
+}
+
+func runWorkflowWithResult[T any](t *testing.T, ctx context.Context, c client.Client, wf interface{}, inputs ...interface{}) (T, error) {
+	instance := runWorkflow(t, ctx, c, wf, inputs...)
+	return client.GetWorkflowResult[T](ctx, c, instance, time.Second*10)
+}

--- a/backend/test/e2e.go
+++ b/backend/test/e2e.go
@@ -44,8 +44,8 @@ func EndToEndBackendTest(t *testing.T, setup func() backend.Backend, teardown fu
 
 				output, err := runWorkflowWithResult[string](t, ctx, c, wf, "hello")
 
-				require.Nil(t, output)
-				require.Error(t, err)
+				require.Zero(t, output)
+				require.ErrorContains(t, err, "workflow 1 not found")
 			},
 		},
 		{
@@ -55,7 +55,7 @@ func EndToEndBackendTest(t *testing.T, setup func() backend.Backend, teardown fu
 				wf := func(ctx workflow.Context) (int, error) {
 					return workflow.ExecuteActivity[int](ctx, workflow.DefaultActivityOptions, a).Get(ctx)
 				}
-				register(t, ctx, w, nil, []interface{}{wf})
+				register(t, ctx, w, []interface{}{wf}, nil)
 
 				output, err := runWorkflowWithResult[int](t, ctx, c, wf)
 

--- a/internal/worker/activity.go
+++ b/internal/worker/activity.go
@@ -16,7 +16,7 @@ import (
 
 type ActivityWorker interface {
 	Start(context.Context) error
-	Stop() error
+	WaitForCompletion() error
 }
 
 type activityWorker struct {
@@ -61,7 +61,7 @@ func (aw *activityWorker) Start(ctx context.Context) error {
 	return nil
 }
 
-func (aw *activityWorker) Stop() error {
+func (aw *activityWorker) WaitForCompletion() error {
 	aw.wg.Wait()
 
 	return nil

--- a/internal/worker/workflow.go
+++ b/internal/worker/workflow.go
@@ -16,7 +16,7 @@ import (
 type WorkflowWorker interface {
 	Start(context.Context) error
 
-	Stop() error
+	WaitForCompletion() error
 }
 
 type workflowWorker struct {
@@ -64,7 +64,7 @@ func (ww *workflowWorker) Start(ctx context.Context) error {
 	return nil
 }
 
-func (ww *workflowWorker) Stop() error {
+func (ww *workflowWorker) WaitForCompletion() error {
 	ww.wg.Wait()
 
 	return nil

--- a/internal/workflow/executor.go
+++ b/internal/workflow/executor.go
@@ -127,7 +127,7 @@ func (e *executor) ExecuteTask(ctx context.Context, t *task.Workflow) (*Executio
 		"instance_id", t.WorkflowInstance.InstanceID,
 		"executed", len(executedEvents),
 		"last_sequence_id", e.lastSequenceID,
-		"completed", e.workflow.Completed(),
+		"completed", completed,
 	)
 
 	return &ExecutionResult{

--- a/samples/simple/simple.go
+++ b/samples/simple/simple.go
@@ -34,7 +34,7 @@ func main() {
 
 	cancel()
 
-	if err := w.Stop(); err != nil {
+	if err := w.WaitForCompletion(); err != nil {
 		panic("could not stop worker" + err.Error())
 	}
 }

--- a/samples/subworkflow/subworkflow.go
+++ b/samples/subworkflow/subworkflow.go
@@ -36,7 +36,7 @@ func main() {
 
 	cancel()
 
-	if err := w.Stop(); err != nil {
+	if err := w.WaitForCompletion(); err != nil {
 		panic("could not stop worker" + err.Error())
 	}
 }

--- a/samples/timer/timer.go
+++ b/samples/timer/timer.go
@@ -32,7 +32,7 @@ func main() {
 	startWorkflow(ctx, c)
 
 	cancel()
-	w.Stop()
+	w.WaitForCompletion()
 }
 
 func startWorkflow(ctx context.Context, c client.Client) {

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -27,11 +27,14 @@ type Registry interface {
 type Worker interface {
 	Registry
 
-	// Start starts the worker
+	// Start starts the worker.
+	//
+	// To stop the worker, cancel the context passed to Start. To wait for completion of the active
+	// work items, call `WaitForCompletion`.
 	Start(ctx context.Context) error
 
-	// Stop stops the worker and waits for in-progress work to complete
-	Stop() error
+	// WaitForCompletion
+	WaitForCompletion() error
 }
 
 type worker struct {
@@ -83,12 +86,12 @@ func (w *worker) Start(ctx context.Context) error {
 	return nil
 }
 
-func (w *worker) Stop() error {
-	if err := w.workflowWorker.Stop(); err != nil {
+func (w *worker) WaitForCompletion() error {
+	if err := w.workflowWorker.WaitForCompletion(); err != nil {
 		return err
 	}
 
-	if err := w.activityWorker.Stop(); err != nil {
+	if err := w.activityWorker.WaitForCompletion(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This PR adds some simple E2E tests for the different backends. The goal is to do some closed-box testing and use the APIs like a consumer would. 

This is a start, planning to add more scenarios -- especially ones that don't follow the "happy path" and to make sure that they don't take down the worker or client. 