### PR TITLE
Improve error messages when workflow replays yield different commands

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -13,7 +13,7 @@ type CommandType int
 const (
 	_ CommandType = iota
 
-	CommandType_ScheduleActivityTask
+	CommandType_ScheduleActivity
 
 	CommandType_ScheduleSubWorkflow
 	CommandType_CancelSubWorkflow
@@ -25,6 +25,27 @@ const (
 
 	CommandType_CompleteWorkflow
 )
+
+func (ct CommandType) String() string {
+	switch ct {
+	case CommandType_ScheduleActivity:
+		return "ScheduleActivityTask"
+	case CommandType_ScheduleSubWorkflow:
+		return "ScheduleSubWorkflow"
+	case CommandType_CancelSubWorkflow:
+		return "CancelSubWorkflow"
+	case CommandType_ScheduleTimer:
+		return "ScheduleTimer"
+	case CommandType_CancelTimer:
+		return "CancelTimer"
+	case CommandType_SideEffect:
+		return "SideEffect"
+	case CommandType_CompleteWorkflow:
+		return "CompleteWorkflow"
+	}
+
+	return ""
+}
 
 type CommandState int
 
@@ -52,7 +73,7 @@ type ScheduleActivityTaskCommandAttr struct {
 func NewScheduleActivityTaskCommand(id int64, name string, inputs []payload.Payload) Command {
 	return Command{
 		ID:   id,
-		Type: CommandType_ScheduleActivityTask,
+		Type: CommandType_ScheduleActivity,
 		Attr: &ScheduleActivityTaskCommandAttr{
 			Name:   name,
 			Inputs: inputs,

--- a/internal/sync/coroutine.go
+++ b/internal/sync/coroutine.go
@@ -85,7 +85,7 @@ func newState() *coState {
 	return &coState{
 		blocking: make(chan bool, 1),
 		unblock:  make(chan bool),
-		// Mostly used while debugging issues, default to discarding log messages
+		// Only used while debugging issues, default to discarding log messages
 		logger: log.New(io.Discard, "[co]", log.LstdFlags),
 		// logger:            log.New(os.Stderr, fmt.Sprintf("[co %v]", i), log.Lmsgprefix|log.Ltime),
 		deadlockDetection: DeadlockDetection,

--- a/internal/sync/future.go
+++ b/internal/sync/future.go
@@ -12,7 +12,7 @@ type Future[T any] interface {
 type SettableFuture[T any] interface {
 	Future[T]
 
-	// Set stores the value and unblocks any waiting consumers
+	// Set stores the value
 	Set(v T, err error) error
 }
 

--- a/internal/workflow/executor_test.go
+++ b/internal/workflow/executor_test.go
@@ -200,7 +200,7 @@ func Test_ExecuteWorkflowWithActivityCommand(t *testing.T) {
 	require.Equal(t, command.Command{
 		ID:    1,
 		State: command.CommandState_Committed,
-		Type:  command.CommandType_ScheduleActivityTask,
+		Type:  command.CommandType_ScheduleActivity,
 		Attr: &command.ScheduleActivityTaskCommandAttr{
 			Name:   "activity1",
 			Inputs: []payload.Payload{inputs},
@@ -309,7 +309,7 @@ func Test_ExecuteWorkflowWithSelector(t *testing.T) {
 	require.Len(t, e.workflowState.Commands(), 2)
 
 	require.Equal(t, command.CommandType_ScheduleTimer, e.workflowState.Commands()[0].Type)
-	require.Equal(t, command.CommandType_ScheduleActivityTask, e.workflowState.Commands()[1].Type)
+	require.Equal(t, command.CommandType_ScheduleActivity, e.workflowState.Commands()[1].Type)
 }
 
 func Test_ExecuteNewEvents(t *testing.T) {


### PR DESCRIPTION
This PR updates some of the error messages returned when a workflow execution shows different behavior from the event in the history. 

It also removes some unnecessary calls to remove (pending) commands from the workflow state. 