### PR TITLE
Simplify sub-workflow cancellation propagation

### DIFF
--- a/backend/sqlite/sqlite.go
+++ b/backend/sqlite/sqlite.go
@@ -135,35 +135,16 @@ func (sb *sqliteBackend) CancelWorkflowInstance(ctx context.Context, instance *w
 
 	// TODO: Combine with event insertion
 	res := tx.QueryRowContext(ctx, "SELECT 1 FROM `instances` WHERE id = ? LIMIT 1", instanceID)
-	if err := res.Scan(nil); err == sql.ErrNoRows {
-		return backend.ErrInstanceNotFound
+	if err := res.Scan(new(int)); err != nil {
+		if err == sql.ErrNoRows {
+			return backend.ErrInstanceNotFound
+		}
+
+		return err
 	}
 
-	// Recursively, find any sub-workflow instance to cancel
-	toCancel := []string{instance.InstanceID}
-
-	for len(toCancel) > 0 {
-		toCancelID := toCancel[0]
-		toCancel = toCancel[1:]
-
-		if err := insertNewEvents(ctx, tx, toCancelID, []history.Event{*event}); err != nil {
-			return fmt.Errorf("inserting cancellation event: %w", err)
-		}
-
-		rows, err := tx.QueryContext(ctx, "SELECT id FROM `instances` WHERE parent_instance_id = ? AND completed_at IS NULL", toCancelID)
-		defer rows.Close()
-		if err != nil {
-			return fmt.Errorf("finding sub-workflow instances: %w", err)
-		}
-
-		for rows.Next() {
-			var subWorkflowInstanceID string
-			if err := rows.Scan(&subWorkflowInstanceID); err != nil {
-				return fmt.Errorf("geting workflow instance for canceling: %w", err)
-			}
-
-			toCancel = append(toCancel, subWorkflowInstanceID)
-		}
+	if err := insertNewEvents(ctx, tx, instanceID, []history.Event{*event}); err != nil {
+		return fmt.Errorf("inserting cancellation event: %w", err)
 	}
 
 	return tx.Commit()

--- a/backend/test/backendtest.go
+++ b/backend/test/backendtest.go
@@ -211,32 +211,6 @@ func BackendTest(t *testing.T, setup func() backend.Backend, teardown func(b bac
 			},
 		},
 		{
-			name: "CancelWorkflow_CancelsSpawnedSubWorkflows",
-			f: func(t *testing.T, ctx context.Context, b backend.Backend) {
-				c := client.New(b)
-				instance := core.NewWorkflowInstance(uuid.NewString(), uuid.NewString())
-				startWorkflow(t, ctx, b, c, instance)
-
-				subInstance1 := core.NewSubWorkflowInstance(uuid.NewString(), uuid.NewString(), instance.InstanceID, 1)
-				startWorkflow(t, ctx, b, c, subInstance1)
-
-				subInstance2 := core.NewSubWorkflowInstance(uuid.NewString(), uuid.NewString(), instance.InstanceID, 2)
-				startWorkflow(t, ctx, b, c, subInstance2)
-
-				err := c.CancelWorkflowInstance(ctx, instance)
-				require.NoError(t, err)
-
-				for i := 0; i < 3; i++ {
-					task, err := b.GetWorkflowTask(ctx)
-					require.NoError(t, err)
-					require.Equal(t, history.EventType_WorkflowExecutionCanceled, task.NewEvents[len(task.NewEvents)-1].Type)
-
-					err = b.CompleteWorkflowTask(ctx, task.ID, task.WorkflowInstance, backend.WorkflowStateActive, task.NewEvents, []history.Event{}, []history.WorkflowEvent{})
-					require.NoError(t, err)
-				}
-			},
-		},
-		{
 			name: "CompleteWorkflowTask_SendsInstanceEvents",
 			f: func(t *testing.T, ctx context.Context, b backend.Backend) {
 				c := client.New(b)


### PR DESCRIPTION
Previously when a workflow was canceled the backend was responsible for finding all sub-workflows and added a cancellation event to their pending event queues. 

This removes this behavior and instead relies on the normal context cancellation logic for propagating cancellation. The workflow that's canceled receives a `..._CANCELED` event. This will cause the root context to be canceled, and trigger the normal logic in `subworkflow.go` that yields cancellation events for an active sub-workflow. 

This will also make it easier to implement #47 in the future