### PR TITLE
Fix timer/sub-workflow cancellation before the command is committed 

### DIFF
--- a/backend/mysql/mysql.go
+++ b/backend/mysql/mysql.go
@@ -188,7 +188,7 @@ func (b *mysqlBackend) GetWorkflowInstanceState(ctx context.Context, instance *w
 	var completedAt sql.NullTime
 	if err := row.Scan(&completedAt); err != nil {
 		if err == sql.ErrNoRows {
-			return backend.WorkflowStateActive, errors.New("could not find workflow instance")
+			return backend.WorkflowStateActive, backend.ErrInstanceNotFound
 		}
 	}
 

--- a/backend/sqlite/sqlite.go
+++ b/backend/sqlite/sqlite.go
@@ -176,7 +176,7 @@ func (s *sqliteBackend) GetWorkflowInstanceState(ctx context.Context, instance *
 	var completedAt sql.NullTime
 	if err := row.Scan(&completedAt); err != nil {
 		if err == sql.ErrNoRows {
-			return backend.WorkflowStateActive, errors.New("could not find workflow instance")
+			return backend.WorkflowStateActive, backend.ErrInstanceNotFound
 		}
 	}
 

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -30,16 +30,20 @@ func (ct CommandType) String() string {
 	switch ct {
 	case CommandType_ScheduleActivity:
 		return "ScheduleActivityTask"
+
 	case CommandType_ScheduleSubWorkflow:
 		return "ScheduleSubWorkflow"
 	case CommandType_CancelSubWorkflow:
 		return "CancelSubWorkflow"
+
 	case CommandType_ScheduleTimer:
 		return "ScheduleTimer"
 	case CommandType_CancelTimer:
 		return "CancelTimer"
+
 	case CommandType_SideEffect:
 		return "SideEffect"
+
 	case CommandType_CompleteWorkflow:
 		return "CompleteWorkflow"
 	}

--- a/internal/workflow/executor.go
+++ b/internal/workflow/executor.go
@@ -340,7 +340,7 @@ func (e *executor) handleTimerCanceled(event history.Event, a *history.TimerCanc
 		return nil
 	}
 
-	if err := f(nil, nil); err != nil {
+	if err := f(nil, sync.Canceled); err != nil {
 		return fmt.Errorf("setting result: %w", err)
 	}
 
@@ -544,14 +544,11 @@ func (e *executor) processCommands(ctx context.Context, t *task.Workflow) (bool,
 		case command.CommandType_CancelTimer:
 			a := c.Attr.(*command.CancelTimerCommandAttr)
 
-			workflowEvents = append(workflowEvents, history.WorkflowEvent{
-				WorkflowInstance: instance,
-				HistoryEvent: e.createNewEvent(
-					history.EventType_TimerCanceled,
-					&history.TimerCanceledAttributes{},
-					history.ScheduleEventID(a.TimerScheduleEventID),
-				),
-			})
+			newEvents = append(newEvents, e.createNewEvent(
+				history.EventType_TimerCanceled,
+				&history.TimerCanceledAttributes{},
+				history.ScheduleEventID(a.TimerScheduleEventID),
+			))
 
 		case command.CommandType_CompleteWorkflow:
 			completed = true

--- a/workflow/timer.go
+++ b/workflow/timer.go
@@ -11,6 +11,7 @@ import (
 func ScheduleTimer(ctx Context, delay time.Duration) Future[struct{}] {
 	f := sync.NewFuture[struct{}]()
 
+	// If the context is already canceled, return immediately.
 	if ctx.Err() != nil {
 		f.Set(struct{}{}, ctx.Err())
 		return f


### PR DESCRIPTION
The way sub-workflow cancellation works is like this:

When you cancel a “parent” workflow via the client, for example, what happens is that a `WorkflowExecutionCanceled` (https://github.com/cschleiden/go-workflows/blob/a20bbf5807d7cfe99d9e5073507de75ff7c49876/internal/history/history.go#L18) event is added to the parent workflows “pending events”, and that workflow is put on the workflow task queue. This will cause the executor to run that workflow, replay the history up to that point, and then execute that `WorkflowExecutionCanceled` event. As a result of that, the root `workflow.Context` that’s passed into the workflow is canceled. 

If the parent workflow has spawned any sub-workflows at that time, this handler that was added to the context is being called: 

https://github.com/cschleiden/go-workflows/blob/a20bbf5807d7cfe99d9e5073507de75ff7c49876/workflow/subworkflow.go#L56-L74

If the sub-workflow hasn't been started yet, and the command isn't committed yet, with **this change** we just remove the command from the queue and immediately return `Canceled` as the result for the sub-workflow `Future[T]`. 

If the command has been committed, which means we created a new sub-workflow instance already, we want to give it a chance to run to completion and perform any cleanup that might be required. In the future we can customize the behavior here, but for now we'll wait for the sub-workflow to finish (see #47).

So we then we add a `CancelSubWorkflowCommand` to the command queue. Once we checkpoint the parent workflow execution, this will cause a `WorkflowExecutionCanceled` event to be added to the sub-workflow’s “pending events” queue. This will be handled similar to the parent workflow ☝️. 

Once the sub-workflow is finished, its result will be sent back to the parent workflow in a `SubWorkflowCompleted` message, which will resolve the `Future[T]` from the earlier `CreateSubWorkflow` call. 

For consistency, scheduling and cancelling a timer is now handled in the same way. 