### PR TITLE
make `SideEffect` usable outside of repo

### DIFF
--- a/workflow/sideeffect.go
+++ b/workflow/sideeffect.go
@@ -7,7 +7,7 @@ import (
 	"github.com/cschleiden/go-workflows/internal/workflowstate"
 )
 
-func SideEffect[TResult any](ctx sync.Context, f func(ctx sync.Context) TResult) Future[TResult] {
+func SideEffect[TResult any](ctx Context, f func(ctx Context) TResult) Future[TResult] {
 	future := sync.NewFuture[TResult]()
 
 	if ctx.Err() != nil {


### PR DESCRIPTION
Right now to use `SideEffect` you need to pass in an anonymous func that takes a `sync.Context`. However, code outside this repo can't reference `sync` since it's an internal package.