### PR TITLE
Honor `lastSequenceID` parameter when retrieving history from redis backend

### DIFF
--- a/backend/redis/instance.go
+++ b/backend/redis/instance.go
@@ -58,7 +58,13 @@ func (rb *redisBackend) CreateWorkflowInstance(ctx context.Context, instance *wo
 }
 
 func (rb *redisBackend) GetWorkflowInstanceHistory(ctx context.Context, instance *core.WorkflowInstance, lastSequenceID *int64) ([]history.Event, error) {
-	msgs, err := rb.rdb.XRange(ctx, historyKey(instance.InstanceID), "-", "+").Result()
+	start := "-"
+
+	if lastSequenceID != nil {
+		start = "(" + historyID(*lastSequenceID)
+	}
+
+	msgs, err := rb.rdb.XRange(ctx, historyKey(instance.InstanceID), start, "+").Result()
 	if err != nil {
 		return nil, err
 	}

--- a/backend/redis/keys.go
+++ b/backend/redis/keys.go
@@ -20,6 +20,10 @@ func historyKey(instanceID string) string {
 	return fmt.Sprintf("history:%v", instanceID)
 }
 
+func historyID(sequenceID int64) string {
+	return fmt.Sprintf("%v-0", sequenceID)
+}
+
 func futureEventsKey() string {
 	return "future-events"
 }

--- a/backend/redis/queue.go
+++ b/backend/redis/queue.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/go-redis/redis/v8"

--- a/backend/redis/queue.go
+++ b/backend/redis/queue.go
@@ -3,8 +3,8 @@ package redis
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/go-redis/redis/v8"
@@ -29,8 +29,6 @@ type TaskItem[T any] struct {
 	// Optional data stored with a task, needs to be serializable
 	Data T
 }
-
-var errTaskAlreadyInQueue = errors.New("task already in queue")
 
 type KeyInfo struct {
 	StreamKey string
@@ -80,7 +78,7 @@ func (q *taskQueue[T]) Keys() KeyInfo {
 	}
 }
 
-// KEYS[1] = stream
+// KEYS[1] = set
 // KEYS[2] = stream
 // ARGV[1] = caller provided id of the task
 // ARGV[2] = additional data to store with the task

--- a/backend/redis/queue_test.go
+++ b/backend/redis/queue_test.go
@@ -73,7 +73,7 @@ func Test_TaskQueue(t *testing.T) {
 				_, err = client.Pipelined(ctx, func(p redis.Pipeliner) error {
 					return q.Enqueue(ctx, p, "t1", nil)
 				})
-				require.Error(t, errTaskAlreadyInQueue, err)
+				require.NoError(t, err)
 
 				task, err := q.Dequeue(ctx, client, lockTimeout, blockTimeout)
 				require.NoError(t, err)


### PR DESCRIPTION
The Redis backend ignored the `lastSequenceID` and always returned the full history. The executor though, assumed that it only received events with sequence id `>=` the given `lastSequenceID` and tried to replay all the received events on its own state. This led to some events being executed twice. Depending on the workflow this was caught or not.

With this change, the redis backend uses sequence IDs as the message ids for the history stream and a direct `XRANGE` query to retrieve events with sequence id >= a given `lastSequenceID`. 