### PR TITLE
Fix uncached command handling

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Tests
       run: |
         go install github.com/jstemmer/go-junit-report/v2@latest
-        go test -race -count 3 -v ./... 2>&1 | go-junit-report -set-exit-code -iocopy -out "${{ github.workspace }}/report.xml"
+        go test -race -count 2 -v ./... 2>&1 | go-junit-report -set-exit-code -iocopy -out "${{ github.workspace }}/report.xml"
 
 
     - name: Test Summary

--- a/backend/mysql/mysql.go
+++ b/backend/mysql/mysql.go
@@ -517,7 +517,7 @@ func (b *mysqlBackend) CompleteWorkflowTask(
 			if event.Type == history.EventType_WorkflowExecutionStarted {
 				a := event.Attributes.(*history.ExecutionStartedAttributes)
 				// Create new instance
-				if err := createInstance(ctx, tx, targetInstance, a.Metadata, true); err != nil {
+				if err := createInstance(ctx, tx, &targetInstance, a.Metadata, true); err != nil {
 					return err
 				}
 

--- a/backend/redis/workflow.go
+++ b/backend/redis/workflow.go
@@ -210,7 +210,7 @@ func (rb *redisBackend) CompleteWorkflowTask(
 			if event.Type == history.EventType_WorkflowExecutionStarted {
 				// Create new instance
 				a := event.Attributes.(*history.ExecutionStartedAttributes)
-				if err := createInstanceP(ctx, p, targetInstance, a.Metadata, true); err != nil {
+				if err := createInstanceP(ctx, p, &targetInstance, a.Metadata, true); err != nil {
 					return err
 				}
 			}
@@ -222,7 +222,7 @@ func (rb *redisBackend) CompleteWorkflowTask(
 		}
 
 		// Try to queue workflow task
-		if targetInstance != instance {
+		if targetInstance != *instance {
 			if err := rb.workflowQueue.Enqueue(ctx, p, targetInstance.InstanceID, nil); err != nil {
 				return fmt.Errorf("enqueuing workflow task: %w", err)
 			}

--- a/backend/sqlite/sqlite.go
+++ b/backend/sqlite/sqlite.go
@@ -406,7 +406,7 @@ func (sb *sqliteBackend) CompleteWorkflowTask(
 			if event.Type == history.EventType_WorkflowExecutionStarted {
 				a := event.Attributes.(*history.ExecutionStartedAttributes)
 				// Create new instance
-				if err := createInstance(ctx, tx, targetInstance, a.Metadata, true); err != nil {
+				if err := createInstance(ctx, tx, &targetInstance, a.Metadata, true); err != nil {
 					return err
 				}
 

--- a/backend/test/e2e.go
+++ b/backend/test/e2e.go
@@ -166,7 +166,8 @@ func EndToEndBackendTest(t *testing.T, setup func() TestBackend, teardown func(b
 					return i * 2, nil
 				}
 
-				ch := make(chan struct{}, 1)
+				// Workflow will be executed multiple times, but the test will wait only once. Create buffered channel
+				ch := make(chan struct{}, 10)
 
 				wf := func(ctx workflow.Context) (int, error) {
 					swfs := make([]workflow.Future[int], 0)
@@ -177,6 +178,7 @@ func EndToEndBackendTest(t *testing.T, setup func() TestBackend, teardown func(b
 					// Unblock test. Should not do this in production code, but here we know that this will be executed in the same process.
 					ch <- struct{}{}
 
+					// Wait for subworkflows to complete
 					r := 0
 
 					for _, f := range swfs {

--- a/internal/command/cancel_subworkflow.go
+++ b/internal/command/cancel_subworkflow.go
@@ -40,6 +40,7 @@ func (c *CancelSubWorkflowCommand) Commit(clock clock.Clock) *CommandResult {
 				&history.SubWorkflowCancellationRequestedAttributes{
 					SubWorkflowInstance: c.SubWorkflowInstance,
 				},
+				history.ScheduleEventID(c.id),
 			),
 		},
 

--- a/internal/command/cancel_timer.go
+++ b/internal/command/cancel_timer.go
@@ -5,16 +5,16 @@ import (
 	"github.com/cschleiden/go-workflows/internal/history"
 )
 
-type cancelTimerCommand struct {
+type CancelTimerCommand struct {
 	command
 
 	TimerScheduleEventID int64
 }
 
-var _ Command = (*cancelTimerCommand)(nil)
+var _ Command = (*CancelTimerCommand)(nil)
 
-func NewCancelTimerCommand(id int64, timerScheduleEventID int64) *cancelTimerCommand {
-	return &cancelTimerCommand{
+func NewCancelTimerCommand(id int64, timerScheduleEventID int64) *CancelTimerCommand {
+	return &CancelTimerCommand{
 		command: command{
 			state: CommandState_Pending,
 			id:    id,
@@ -23,11 +23,11 @@ func NewCancelTimerCommand(id int64, timerScheduleEventID int64) *cancelTimerCom
 	}
 }
 
-func (*cancelTimerCommand) Type() string {
+func (*CancelTimerCommand) Type() string {
 	return "CancelTimer"
 }
 
-func (c *cancelTimerCommand) Commit(clock clock.Clock) *CommandResult {
+func (c *CancelTimerCommand) Commit(clock clock.Clock) *CommandResult {
 	c.commit()
 
 	return &CommandResult{

--- a/internal/command/schedule_subworkflow.go
+++ b/internal/command/schedule_subworkflow.go
@@ -49,7 +49,7 @@ func (c *ScheduleSubWorkflowCommand) Commit(clock clock.Clock) *CommandResult {
 	c.commit()
 
 	return &CommandResult{
-		// Record scheduled sub-workflow
+		// Record scheduled sub-workflow for source workflow instance
 		Events: []history.Event{
 			history.NewPendingEvent(
 				clock.Now(),

--- a/internal/command/sideeffect.go
+++ b/internal/command/sideeffect.go
@@ -6,16 +6,16 @@ import (
 	"github.com/cschleiden/go-workflows/internal/payload"
 )
 
-type sideEffectCommand struct {
+type SideEffectCommand struct {
 	command
 
 	result payload.Payload
 }
 
-var _ Command = (*sideEffectCommand)(nil)
+var _ Command = (*SideEffectCommand)(nil)
 
-func NewSideEffectCommand(id int64, result payload.Payload) *sideEffectCommand {
-	return &sideEffectCommand{
+func NewSideEffectCommand(id int64, result payload.Payload) *SideEffectCommand {
+	return &SideEffectCommand{
 		command: command{
 			state: CommandState_Pending,
 			id:    id,
@@ -24,11 +24,11 @@ func NewSideEffectCommand(id int64, result payload.Payload) *sideEffectCommand {
 	}
 }
 
-func (c *sideEffectCommand) Type() string {
+func (c *SideEffectCommand) Type() string {
 	return "SideEffect"
 }
 
-func (c *sideEffectCommand) Commit(clock clock.Clock) *CommandResult {
+func (c *SideEffectCommand) Commit(clock clock.Clock) *CommandResult {
 	c.commit()
 
 	return &CommandResult{

--- a/internal/history/grouping.go
+++ b/internal/history/grouping.go
@@ -2,15 +2,17 @@ package history
 
 import "github.com/cschleiden/go-workflows/internal/core"
 
-func EventsByWorkflowInstance(events []WorkflowEvent) map[*core.WorkflowInstance][]Event {
-	groupedEvents := make(map[*core.WorkflowInstance][]Event)
+func EventsByWorkflowInstance(events []WorkflowEvent) map[core.WorkflowInstance][]Event {
+	groupedEvents := make(map[core.WorkflowInstance][]Event)
 
 	for _, m := range events {
-		if _, ok := groupedEvents[m.WorkflowInstance]; !ok {
-			groupedEvents[m.WorkflowInstance] = []Event{}
+		instance := *m.WorkflowInstance
+
+		if _, ok := groupedEvents[instance]; !ok {
+			groupedEvents[instance] = []Event{}
 		}
 
-		groupedEvents[m.WorkflowInstance] = append(groupedEvents[m.WorkflowInstance], m.HistoryEvent)
+		groupedEvents[instance] = append(groupedEvents[instance], m.HistoryEvent)
 	}
 
 	return groupedEvents

--- a/internal/history/grouping_test.go
+++ b/internal/history/grouping_test.go
@@ -1,0 +1,28 @@
+package history
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cschleiden/go-workflows/internal/core"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGrouping_MultipleEventsSameInstance(t *testing.T) {
+	id := uuid.NewString()
+
+	r := EventsByWorkflowInstance([]WorkflowEvent{
+		{
+			WorkflowInstance: core.NewWorkflowInstance(id, "exid"),
+			HistoryEvent:     NewPendingEvent(time.Now(), EventType_SubWorkflowScheduled, &SubWorkflowScheduledAttributes{}),
+		},
+		{
+			WorkflowInstance: core.NewWorkflowInstance(id, "exid"),
+			HistoryEvent:     NewPendingEvent(time.Now(), EventType_SubWorkflowScheduled, &SubWorkflowScheduledAttributes{}),
+		},
+	})
+
+	require.Len(t, r, 1)
+	require.Len(t, r[*core.NewWorkflowInstance(id, "exid")], 2)
+}

--- a/internal/workflow/executor.go
+++ b/internal/workflow/executor.go
@@ -434,6 +434,10 @@ func (e *executor) handleSubWorkflowScheduled(event history.Event, a *history.Su
 		return fmt.Errorf("previous workflow execution scheduled different type of sub workflow: %s, %s", a.Name, sswc.Name)
 	}
 
+	// If we are replaying this event, the command will have generated a new instance ID. Ensure we use the same one as
+	// when the command was originally committed.
+	sswc.Instance = a.SubWorkflowInstance
+
 	c.Done()
 
 	return nil

--- a/internal/workflow/executor.go
+++ b/internal/workflow/executor.go
@@ -162,7 +162,7 @@ func (e *executor) ExecuteTask(ctx context.Context, t *task.Workflow) (*Executio
 		workflowEvents = append(workflowEvents, r.WorkflowEvents...)
 	}
 
-	// Events from command don't have to be executed again, add them to the executed events.
+	// Events from commands don't have to be executed again, add them to the executed events.
 	executedEvents = append(executedEvents, newCommandEvents...)
 
 	// Set SequenceIDs for all executed events

--- a/internal/workflow/executor.go
+++ b/internal/workflow/executor.go
@@ -234,6 +234,7 @@ func (e *executor) executeEvent(event history.Event) error {
 		"seq_id", event.SequenceID,
 		"event_type", event.Type,
 		"schedule_event_id", event.ScheduleEventID,
+		"is_replaying", e.workflowState.Replaying(),
 	)
 
 	var err error

--- a/internal/workflow/executor.go
+++ b/internal/workflow/executor.go
@@ -116,7 +116,7 @@ func (e *executor) ExecuteTask(ctx context.Context, t *task.Workflow) (*Executio
 			e.workflowCompleted(nil, err)
 			skipNewEvents = true
 		} else if t.LastSequenceID != e.lastSequenceID {
-			logger.Debug("Task has newer history than current state", "task_sequence_id", t.LastSequenceID, "sequence_id", e.lastSequenceID)
+			logger.Error("After replaying history, task still has newer history than current state", "task_sequence_id", t.LastSequenceID, "local_sequence_id", e.lastSequenceID)
 
 			return nil, errors.New("even after fetching history and replaying history executor state does not match task")
 		}

--- a/workflow/activity.go
+++ b/workflow/activity.go
@@ -66,7 +66,7 @@ func executeActivity[TResult any](ctx Context, options ActivityOptions, attempt 
 		if c, ok := d.(sync.ChannelInternal[struct{}]); ok {
 			if _, ok := c.ReceiveNonBlocking(); ok {
 				// Workflow has been canceled, check if the activity has already been scheduled, no need to schedule otherwise
-				if cmd.State() != command.CommandState_Committed {
+				if !cmd.Committed() {
 					cmd.Done()
 					wfState.RemoveFuture(scheduleEventID)
 					f.Set(*new(TResult), sync.Canceled)

--- a/workflow/subworkflow.go
+++ b/workflow/subworkflow.go
@@ -71,7 +71,7 @@ func createSubWorkflowInstance[TResult any](ctx sync.Context, options SubWorkflo
 	// Check if the channel is cancelable
 	if c, cancelable := ctx.Done().(sync.CancelChannel); cancelable {
 		c.AddReceiveCallback(func(v struct{}, ok bool) {
-			if cmd.State() == command.CommandState_Committed {
+			if cmd.Committed() {
 				// The command is committed, that means the sub-workflow is already started. Create and add a cancel command
 				// to stop the sub-workflow execution.
 				cancelScheduleEventID := wfState.GetNextScheduleEventID()

--- a/workflow/timer.go
+++ b/workflow/timer.go
@@ -42,7 +42,7 @@ func ScheduleTimer(ctx Context, delay time.Duration) Future[struct{}] {
 		// Register a callback for when it's canceled. The only operation on the `Done` channel
 		// is that it's closed when the context is canceled.
 		c.AddReceiveCallback(func(v struct{}, ok bool) {
-			if timerCmd.State() == command.CommandState_Committed {
+			if timerCmd.Committed() {
 				// If the timer command is already committed, create a cancel command to allow the backend
 				// to clean up the scheduled timer message.
 				cancelScheduleEventID := wfState.GetNextScheduleEventID()


### PR DESCRIPTION
When executing workflow instances without cached executor instances, during replay some commands weren't put into the correct state. This lead to required events not being generated. Most notably, scheduled future events for cancelled timers were not cleaned up. This could lead to events being delivered to an already completed workflow instance, which leads to errors when trying to process those.

This also raised some gaps in the testing. With this change all e2e tests are run twice, with executor instance caching and without. This increases the time for running all tests quite a bit, but the increased coverage is worth it. 