### PR TITLE
Adjust sub-workflow retry behavior

### DIFF
--- a/internal/workflow/executor_test.go
+++ b/internal/workflow/executor_test.go
@@ -317,8 +317,8 @@ func Test_ExecuteWorkflowWithSelector(t *testing.T) {
 	require.Equal(t, 1, workflowWithSelectorHits)
 	require.Len(t, e.workflowState.Commands(), 2)
 
-	require.IsType(t, &command.ScheduleTimerCommand{}, e.workflowState.Commands()[0])
-	require.IsType(t, &command.ScheduleActivityCommand{}, e.workflowState.Commands()[1])
+	require.IsType(t, &command.ScheduleActivityCommand{}, e.workflowState.Commands()[0])
+	require.IsType(t, &command.ScheduleTimerCommand{}, e.workflowState.Commands()[1])
 }
 
 func Test_ExecuteNewEvents(t *testing.T) {

--- a/workflow/subworkflow.go
+++ b/workflow/subworkflow.go
@@ -22,9 +22,16 @@ type SubWorkflowOptions struct {
 	RetryOptions RetryOptions
 }
 
-var DefaultSubWorkflowOptions = SubWorkflowOptions{
-	RetryOptions: DefaultRetryOptions,
-}
+var (
+	DefaultSubWorkflowRetryOptions = RetryOptions{
+		// Disable retries by default for sub-workflows
+		MaxAttempts: 1,
+	}
+
+	DefaultSubWorkflowOptions = SubWorkflowOptions{
+		RetryOptions: DefaultSubWorkflowRetryOptions,
+	}
+)
 
 func CreateSubWorkflowInstance[TResult any](ctx sync.Context, options SubWorkflowOptions, workflow interface{}, args ...interface{}) Future[TResult] {
 	return withRetries(ctx, options.RetryOptions, func(ctx sync.Context, attempt int) Future[TResult] {


### PR DESCRIPTION
Closes #119 
Supports #121

This also helps with a "race condition" when writing workflows. From my notes:

- There is race condition, where sending a signal to a workflow instance that doesn't yet exist can lead to an issue. It's easy to hit with code like this:  
  ``` go
  func Workflow(ctx workflow.Context) error {
    subWorkflowInstanceID := "..."
    
    // (1)
    f := workflow.CreateSubWorkflowInstance(ctx, ..., SubWorkflow)
    
    // (2)
    workflow.SignalWorkflow(ctx, subWorkflowInstanceID, "signal", "value")  
    
    result, err := f.Get(ctx)
  }
  ```
    
  (1) is implemented via `withRetry` by default, which uses a Coroutine to schedule the sub-workflow. Since there is no `Yield` before (2), the `SignalWorkflow` command is created *before* the `CreateSubWorkflowInstance` command. `SignalWorkflow` just delivers an event to another instance, independent of whether it exists or not. This can create a workflow instance that's in a bad state and cannot be worked on.  
- Solutions:  
	1. Change how `SignalWorkflow` is processed in the backend, allowing a status to be sent back. This could allow users to get a future from the `SignalWorkflow` call and check the result. This would not be the best developer experience, the unexpected behavior with (1) and (2) might still occur.
	2. Change `CreateSubWorkflowInstance` to create the initial command outside of the co-routine. This should ensure the workflow instance -- if it can be created and doesn't run into other issues like the workflow not being found -- will exist when we deliver the `Signal` message


I went with option (2) here. 

