### PR TITLE
Add Send case to the Select function

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,8 @@ Due its non-deterministic behavior you must not use a `select` statement in work
 var f1 workflow.Future[int]
 var c workflow.Channel[int]
 
+value := 42
+
 workflow.Select(
 	ctx,
 	workflow.Await(f1, func (ctx workflow.Context, f Future[int]) {
@@ -418,6 +420,9 @@ workflow.Select(
 	}),
 	workflow.Receive(c, func (ctx workflow.Context, v int, ok bool) {
 		// use v
+	}),
+	workflow.Send(c, &value, func (ctx workflow.Context) {
+		// value has been sent to the channel
 	}),
 	workflow.Default(ctx, func (ctx workflow.Context) {
 		// ...

--- a/internal/sync/channel.go
+++ b/internal/sync/channel.go
@@ -155,6 +155,14 @@ func (c *channel[T]) canReceive() bool {
 	return c.hasValue() || len(c.senders) > 0 || c.closed
 }
 
+func (c *channel[T]) canSend() bool {
+	if c.closed {
+		return false
+	}
+
+	return len(c.receivers) > 0 || c.hasCapacity()
+}
+
 func (c *channel[T]) trySend(v T) bool {
 	// If closed, we can't send, panic.
 	if c.closed {

--- a/workflow/sync.go
+++ b/workflow/sync.go
@@ -5,36 +5,46 @@ import (
 )
 
 type Context = sync.Context
-type WaitGroup = sync.WaitGroup
 
 var Canceled = sync.Canceled
 
+type WaitGroup = sync.WaitGroup
+
+func NewWaitGroup() WaitGroup {
+	return sync.NewWaitGroup()
+}
+
+// Go spawns a workflow goroutine
 func Go(ctx Context, f func(ctx Context)) {
 	sync.Go(ctx, f)
 }
 
 type SelectCase = sync.SelectCase
 
+// Select is the workflow-save equivalent of the select statement.
 func Select(ctx Context, cases ...SelectCase) {
 	sync.Select(ctx, cases...)
 }
 
+// Await calls the provided handler when the given future is ready.
 func Await[T any](f Future[T], handler func(Context, Future[T])) SelectCase {
 	return sync.Await[T](f, func(ctx sync.Context, f sync.Future[T]) {
 		handler(ctx, f)
 	})
 }
 
+// Receive calls the provided handler if the given channel can receive a value. The handler receives
+// the received value, and the ok flag indicating whether the value was received or the channel was closed.
 func Receive[T any](c Channel[T], handler func(ctx Context, v T, ok bool)) SelectCase {
-	return sync.Receive[T](c, func(ctx sync.Context, v T, ok bool) {
-		handler(ctx, v, ok)
-	})
+	return sync.Receive[T](c, handler)
 }
 
+// Send calls the provided handler if the given value can be sent to the channel.
+func Send[T any](c Channel[T], value *T, handler func(ctx Context)) SelectCase {
+	return sync.Send[T](c, value, handler)
+}
+
+// Default calls the given handler if none of the other cases match.
 func Default(handler func(Context)) SelectCase {
 	return sync.Default(handler)
-}
-
-func NewWaitGroup() WaitGroup {
-	return sync.NewWaitGroup()
 }


### PR DESCRIPTION
This adds a `Send` case to the `Select` function, similar to:

```go
var c chan int

select {
  case c <- 42:
    // Value was sent 
}
```