### PR TITLE
Use exponential backoff when waiting for workflow results

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Tests
       run: |
         go install github.com/jstemmer/go-junit-report/v2@latest
-        go test -race -count 2 -v ./... 2>&1 | go-junit-report -set-exit-code -iocopy -out "${{ github.workspace }}/report.xml"
+        go test -race -count 1 -v ./... 2>&1 | go-junit-report -set-exit-code -iocopy -out "${{ github.workspace }}/report.xml"
 
 
     - name: Test Summary

--- a/backend/test/e2e.go
+++ b/backend/test/e2e.go
@@ -476,11 +476,13 @@ func EndToEndBackendTest(t *testing.T, setup func() TestBackend, teardown func(b
 				w := worker.New(b, workerOptions)
 
 				t.Cleanup(func() {
-					cancel()
+					// Wait for in-progress executions to finish
 					if err := w.WaitForCompletion(); err != nil {
 						log.Println("Worker did not stop in time")
 						t.FailNow()
 					}
+
+					cancel()
 
 					if teardown != nil {
 						teardown(b)


### PR DESCRIPTION
Primary motivation at this point is to reduce the time it takes to run the tests. With this the Redis integration tests go from 40s to 3s, same for SQLite. 

MySQL is faster, but still suffers from the `CREATE/DROP` DB setup/teardown. 