### PR TITLE
Discard events for completed workflow instances

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -15,13 +15,6 @@ import (
 var ErrInstanceNotFound = errors.New("workflow instance not found")
 var ErrInstanceAlreadyExists = errors.New("workflow instance already exists")
 
-type WorkflowState int
-
-const (
-	WorkflowStateActive WorkflowState = iota
-	WorkflowStateFinished
-)
-
 const TracerName = "go-workflow"
 
 //go:generate mockery --name=Backend --inpackage
@@ -33,7 +26,7 @@ type Backend interface {
 	CancelWorkflowInstance(ctx context.Context, instance *workflow.Instance, cancelEvent *history.Event) error
 
 	// GetWorkflowInstanceState returns the state of the given workflow instance
-	GetWorkflowInstanceState(ctx context.Context, instance *workflow.Instance) (WorkflowState, error)
+	GetWorkflowInstanceState(ctx context.Context, instance *workflow.Instance) (core.WorkflowInstanceState, error)
 
 	// GetWorkflowInstanceHistory returns the workflow history for the given instance. When lastSequenceID
 	// is given, only events after that event are returned. Otherwise the full history is returned.
@@ -54,7 +47,7 @@ type Backend interface {
 	// which will be added to the workflow instance history. workflowEvents are new events for the
 	// completed or other workflow instances.
 	CompleteWorkflowTask(
-		ctx context.Context, task *task.Workflow, instance *workflow.Instance, state WorkflowState,
+		ctx context.Context, task *task.Workflow, instance *workflow.Instance, state core.WorkflowInstanceState,
 		executedEvents, activityEvents, timerEvents []history.Event, workflowEvents []history.WorkflowEvent) error
 
 	// GetActivityTask returns a pending activity task or nil if there are no pending activities

--- a/backend/mock_Backend.go
+++ b/backend/mock_Backend.go
@@ -51,11 +51,12 @@ func (_m *MockBackend) CompleteActivityTask(ctx context.Context, instance *core.
 }
 
 // CompleteWorkflowTask provides a mock function with given fields: ctx, _a1, instance, state, executedEvents, activityEvents, timerEvents, workflowEvents
-func (_m *MockBackend) CompleteWorkflowTask(ctx context.Context, _a1 *task.Workflow, instance *core.WorkflowInstance, state WorkflowState, executedEvents []history.Event, activityEvents []history.Event, timerEvents []history.Event, workflowEvents []history.WorkflowEvent) error {
+func (_m *MockBackend) CompleteWorkflowTask(
+	ctx context.Context, _a1 *task.Workflow, instance *core.WorkflowInstance, state core.WorkflowInstanceState, executedEvents []history.Event, activityEvents []history.Event, timerEvents []history.Event, workflowEvents []history.WorkflowEvent) error {
 	ret := _m.Called(ctx, _a1, instance, state, executedEvents, activityEvents, timerEvents, workflowEvents)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, *task.Workflow, *core.WorkflowInstance, WorkflowState, []history.Event, []history.Event, []history.Event, []history.WorkflowEvent) error); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *task.Workflow, *core.WorkflowInstance, core.WorkflowInstanceState, []history.Event, []history.Event, []history.Event, []history.WorkflowEvent) error); ok {
 		r0 = rf(ctx, _a1, instance, state, executedEvents, activityEvents, timerEvents, workflowEvents)
 	} else {
 		r0 = ret.Error(0)
@@ -153,14 +154,14 @@ func (_m *MockBackend) GetWorkflowInstanceHistory(ctx context.Context, instance 
 }
 
 // GetWorkflowInstanceState provides a mock function with given fields: ctx, instance
-func (_m *MockBackend) GetWorkflowInstanceState(ctx context.Context, instance *core.WorkflowInstance) (WorkflowState, error) {
+func (_m *MockBackend) GetWorkflowInstanceState(ctx context.Context, instance *core.WorkflowInstance) (core.WorkflowInstanceState, error) {
 	ret := _m.Called(ctx, instance)
 
-	var r0 WorkflowState
-	if rf, ok := ret.Get(0).(func(context.Context, *core.WorkflowInstance) WorkflowState); ok {
+	var r0 core.WorkflowInstanceState
+	if rf, ok := ret.Get(0).(func(context.Context, *core.WorkflowInstance) core.WorkflowInstanceState); ok {
 		r0 = rf(ctx, instance)
 	} else {
-		r0 = ret.Get(0).(WorkflowState)
+		r0 = ret.Get(0).(core.WorkflowInstanceState)
 	}
 
 	var r1 error

--- a/backend/mysql/diagnostics.go
+++ b/backend/mysql/diagnostics.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"time"
 
-	"github.com/cschleiden/go-workflows/backend"
 	"github.com/cschleiden/go-workflows/diag"
 	"github.com/cschleiden/go-workflows/internal/core"
 )
@@ -58,9 +57,9 @@ func (mb *mysqlBackend) GetWorkflowInstances(ctx context.Context, afterInstanceI
 			return nil, err
 		}
 
-		var state backend.WorkflowState
+		var state core.WorkflowInstanceState
 		if completedAt != nil {
-			state = backend.WorkflowStateFinished
+			state = core.WorkflowInstanceStateFinished
 		}
 
 		instances = append(instances, &diag.WorkflowInstanceRef{
@@ -96,9 +95,9 @@ func (mb *mysqlBackend) GetWorkflowInstance(ctx context.Context, instanceID stri
 		return nil, err
 	}
 
-	var state backend.WorkflowState
+	var state core.WorkflowInstanceState
 	if completedAt != nil {
-		state = backend.WorkflowStateFinished
+		state = core.WorkflowInstanceStateFinished
 	}
 
 	return &diag.WorkflowInstanceRef{

--- a/backend/redis/instance.go
+++ b/backend/redis/instance.go
@@ -82,10 +82,10 @@ func (rb *redisBackend) GetWorkflowInstanceHistory(ctx context.Context, instance
 	return events, nil
 }
 
-func (rb *redisBackend) GetWorkflowInstanceState(ctx context.Context, instance *core.WorkflowInstance) (backend.WorkflowState, error) {
+func (rb *redisBackend) GetWorkflowInstanceState(ctx context.Context, instance *core.WorkflowInstance) (core.WorkflowInstanceState, error) {
 	instanceState, err := readInstance(ctx, rb.rdb, instance.InstanceID)
 	if err != nil {
-		return backend.WorkflowStateActive, err
+		return core.WorkflowInstanceStateActive, err
 	}
 
 	return instanceState.State, nil
@@ -110,8 +110,8 @@ func (rb *redisBackend) CancelWorkflowInstance(ctx context.Context, instance *co
 }
 
 type instanceState struct {
-	Instance *core.WorkflowInstance `json:"instance,omitempty"`
-	State    backend.WorkflowState  `json:"state,omitempty"`
+	Instance *core.WorkflowInstance     `json:"instance,omitempty"`
+	State    core.WorkflowInstanceState `json:"state,omitempty"`
 
 	Metadata *core.WorkflowMetadata `json:"metadata,omitempty"`
 
@@ -128,7 +128,7 @@ func createInstanceP(ctx context.Context, p redis.Pipeliner, instance *core.Work
 
 	b, err := json.Marshal(&instanceState{
 		Instance:  instance,
-		State:     backend.WorkflowStateActive,
+		State:     core.WorkflowInstanceStateActive,
 		Metadata:  metadata,
 		CreatedAt: createdAt,
 	})

--- a/backend/redis/workflow.go
+++ b/backend/redis/workflow.go
@@ -100,23 +100,6 @@ func (rb *redisBackend) GetWorkflowTask(ctx context.Context) (*task.Workflow, er
 		newEvents = append(newEvents, event)
 	}
 
-	if instanceState.State == core.WorkflowInstanceStateFinished {
-		l := rb.Logger().With(
-			"task_id", instanceTask.TaskID,
-			"id", instanceTask.ID,
-			"instance_id", instanceState.Instance.InstanceID)
-
-		// This should never happen. For now, log information and then panic.
-		l.Error("got workflow task for finished workflow instance")
-
-		// Log events that lead to this task
-		for _, event := range newEvents {
-			l.Error("pending_event", "id", event.ID, "event_type", event.Type.String(), "schedule_event_id", event.ScheduleEventID)
-		}
-
-		panic("Dequeued already finished workflow instance task")
-	}
-
 	return &task.Workflow{
 		ID:                    instanceTask.TaskID,
 		WorkflowInstance:      instanceState.Instance,

--- a/backend/sqlite/diagnostics.go
+++ b/backend/sqlite/diagnostics.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"time"
 
-	"github.com/cschleiden/go-workflows/backend"
 	"github.com/cschleiden/go-workflows/diag"
 	"github.com/cschleiden/go-workflows/internal/core"
 )
@@ -58,9 +57,9 @@ func (sb *sqliteBackend) GetWorkflowInstances(ctx context.Context, afterInstance
 			return nil, err
 		}
 
-		var state backend.WorkflowState
+		var state core.WorkflowInstanceState
 		if completedAt != nil {
-			state = backend.WorkflowStateFinished
+			state = core.WorkflowInstanceStateFinished
 		}
 
 		instances = append(instances, &diag.WorkflowInstanceRef{
@@ -96,9 +95,9 @@ func (sb *sqliteBackend) GetWorkflowInstance(ctx context.Context, instanceID str
 		return nil, err
 	}
 
-	var state backend.WorkflowState
+	var state core.WorkflowInstanceState
 	if completedAt != nil {
-		state = backend.WorkflowStateFinished
+		state = core.WorkflowInstanceStateFinished
 	}
 
 	return &diag.WorkflowInstanceRef{

--- a/backend/test/backendtest.go
+++ b/backend/test/backendtest.go
@@ -145,11 +145,11 @@ func BackendTest(t *testing.T, setup func() TestBackend, teardown func(b TestBac
 				require.NotNil(t, tk)
 
 				// Complete workflow task
-				err = b.CompleteWorkflowTask(ctx, tk, wfi, backend.WorkflowStateActive, tk.NewEvents, []history.Event{}, []history.Event{}, []history.WorkflowEvent{})
+				err = b.CompleteWorkflowTask(ctx, tk, wfi, core.WorkflowInstanceStateActive, tk.NewEvents, []history.Event{}, []history.Event{}, []history.WorkflowEvent{})
 				require.NoError(t, err)
 
 				// Task is already completed, this should error
-				err = b.CompleteWorkflowTask(ctx, tk, wfi, backend.WorkflowStateActive, tk.NewEvents, []history.Event{}, []history.Event{}, []history.WorkflowEvent{})
+				err = b.CompleteWorkflowTask(ctx, tk, wfi, core.WorkflowInstanceStateActive, tk.NewEvents, []history.Event{}, []history.Event{}, []history.WorkflowEvent{})
 				require.Error(t, err)
 			},
 		},
@@ -185,7 +185,7 @@ func BackendTest(t *testing.T, setup func() TestBackend, teardown func(b TestBac
 
 				workflowEvents := []history.WorkflowEvent{}
 
-				err = b.CompleteWorkflowTask(ctx, task, wfi, backend.WorkflowStateActive, events, activityEvents, []history.Event{}, workflowEvents)
+				err = b.CompleteWorkflowTask(ctx, task, wfi, core.WorkflowInstanceStateActive, events, activityEvents, []history.Event{}, workflowEvents)
 				require.NoError(t, err)
 
 				time.Sleep(time.Second)
@@ -228,7 +228,7 @@ func BackendTest(t *testing.T, setup func() TestBackend, teardown func(b TestBac
 					events[i].SequenceID = sequenceID
 				}
 
-				err = b.CompleteWorkflowTask(ctx, task, wfi, backend.WorkflowStateFinished, events, []history.Event{}, []history.Event{}, []history.WorkflowEvent{})
+				err = b.CompleteWorkflowTask(ctx, task, wfi, core.WorkflowInstanceStateFinished, events, []history.Event{}, []history.Event{}, []history.WorkflowEvent{})
 				require.NoError(t, err)
 
 				time.Sleep(time.Second)
@@ -236,7 +236,7 @@ func BackendTest(t *testing.T, setup func() TestBackend, teardown func(b TestBac
 				db := b.(diag.Backend)
 				s, err := db.GetWorkflowInstance(ctx, wfi.InstanceID)
 				require.NoError(t, err)
-				require.Equal(t, backend.WorkflowStateFinished, s.State)
+				require.Equal(t, core.WorkflowInstanceStateFinished, s.State)
 				require.NotNil(t, s.CompletedAt)
 			},
 		},
@@ -290,7 +290,7 @@ func BackendTest(t *testing.T, setup func() TestBackend, teardown func(b TestBac
 				// Simulate context and sub-workflow cancellation
 				task, err := b.GetWorkflowTask(ctx)
 				require.NoError(t, err)
-				err = b.CompleteWorkflowTask(ctx, task, instance, backend.WorkflowStateActive, task.NewEvents, []history.Event{}, []history.Event{}, []history.WorkflowEvent{
+				err = b.CompleteWorkflowTask(ctx, task, instance, core.WorkflowInstanceStateActive, task.NewEvents, []history.Event{}, []history.Event{}, []history.WorkflowEvent{
 					{
 						WorkflowInstance: subInstance1,
 						HistoryEvent: history.NewHistoryEvent(1, time.Now(), history.EventType_WorkflowExecutionCanceled, &history.SubWorkflowCancellationRequestedAttributes{
@@ -344,6 +344,6 @@ func startWorkflow(t *testing.T, ctx context.Context, b backend.Backend, c clien
 	require.NoError(t, err)
 
 	err = b.CompleteWorkflowTask(
-		ctx, task, instance, backend.WorkflowStateActive, task.NewEvents, []history.Event{}, []history.Event{}, []history.WorkflowEvent{})
+		ctx, task, instance, core.WorkflowInstanceStateActive, task.NewEvents, []history.Event{}, []history.Event{}, []history.WorkflowEvent{})
 	require.NoError(t, err)
 }

--- a/backend/test/e2e.go
+++ b/backend/test/e2e.go
@@ -539,13 +539,13 @@ func EndToEndBackendTest(t *testing.T, setup func() TestBackend, teardown func(b
 				w := worker.New(b, workerOptions)
 
 				t.Cleanup(func() {
+					cancel()
+
 					// Wait for in-progress executions to finish
 					if err := w.WaitForCompletion(); err != nil {
 						log.Println("Worker did not stop in time")
 						t.FailNow()
 					}
-
-					cancel()
 
 					if teardown != nil {
 						teardown(b)

--- a/backend/test/e2e.go
+++ b/backend/test/e2e.go
@@ -156,6 +156,23 @@ func EndToEndBackendTest(t *testing.T, setup func() TestBackend, teardown func(b
 			},
 		},
 		{
+			name: "Signal_after_completion",
+			f: func(t *testing.T, ctx context.Context, c client.Client, w worker.Worker, b TestBackend) {
+				wf := func(ctx workflow.Context) error {
+					return nil
+				}
+				register(t, ctx, w, []interface{}{wf}, nil)
+
+				// Run workflow to completion
+				instance := runWorkflow(t, ctx, c, wf)
+				_, err := client.GetWorkflowResult[int](ctx, c, instance, time.Second*20)
+				require.NoError(t, err)
+
+				err = c.SignalWorkflow(ctx, instance.InstanceID, "signal", nil)
+				require.NoError(t, err)
+			},
+		},
+		{
 			name: "SubWorkflow_Simple",
 			f: func(t *testing.T, ctx context.Context, c client.Client, w worker.Worker, b TestBackend) {
 				swf := func(ctx workflow.Context, i int) (int, error) {

--- a/client/client.go
+++ b/client/client.go
@@ -146,7 +146,7 @@ func (c *client) WaitForWorkflowInstance(ctx context.Context, instance *workflow
 			return fmt.Errorf("getting workflow state: %w", err)
 		}
 
-		if s == backend.WorkflowStateFinished {
+		if s == core.WorkflowInstanceStateFinished {
 			return nil
 		}
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -23,7 +23,7 @@ func Test_Client_GetWorkflowResultTimeout(t *testing.T) {
 	ctx := context.Background()
 
 	b := &backend.MockBackend{}
-	b.On("GetWorkflowInstanceState", mock.Anything, instance).Return(backend.WorkflowStateActive, nil)
+	b.On("GetWorkflowInstanceState", mock.Anything, instance).Return(core.WorkflowInstanceStateActive, nil)
 
 	c := &client{
 		backend: b,
@@ -46,11 +46,11 @@ func Test_Client_GetWorkflowResultSuccess(t *testing.T) {
 	r, _ := converter.DefaultConverter.To(42)
 
 	b := &backend.MockBackend{}
-	b.On("GetWorkflowInstanceState", mock.Anything, instance).Return(backend.WorkflowStateActive, nil).Once().Run(func(args mock.Arguments) {
+	b.On("GetWorkflowInstanceState", mock.Anything, instance).Return(core.WorkflowInstanceStateActive, nil).Once().Run(func(args mock.Arguments) {
 		// After the first call, advance the clock to immediately go to the second call below
 		mockClock.Add(time.Second)
 	})
-	b.On("GetWorkflowInstanceState", mock.Anything, instance).Return(backend.WorkflowStateFinished, nil)
+	b.On("GetWorkflowInstanceState", mock.Anything, instance).Return(core.WorkflowInstanceStateFinished, nil)
 	b.On("GetWorkflowInstanceHistory", mock.Anything, instance, (*int64)(nil)).Return([]history.Event{
 		history.NewHistoryEvent(1, time.Now(), history.EventType_WorkflowExecutionStarted, &history.ExecutionStartedAttributes{}),
 		history.NewHistoryEvent(2, time.Now(), history.EventType_WorkflowExecutionFinished, &history.ExecutionCompletedAttributes{

--- a/diag/backend.go
+++ b/diag/backend.go
@@ -11,10 +11,10 @@ import (
 // json: serialization in this file needs to be kept in sync with client.ts in the web app
 
 type WorkflowInstanceRef struct {
-	Instance    *core.WorkflowInstance `json:"instance,omitempty"`
-	CreatedAt   time.Time              `json:"created_at,omitempty"`
-	CompletedAt *time.Time             `json:"completed_at,omitempty"`
-	State       backend.WorkflowState  `json:"state"`
+	Instance    *core.WorkflowInstance     `json:"instance,omitempty"`
+	CreatedAt   time.Time                  `json:"created_at,omitempty"`
+	CompletedAt *time.Time                 `json:"completed_at,omitempty"`
+	State       core.WorkflowInstanceState `json:"state"`
 }
 
 type Event struct {

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/bombsimon/wsl/v3 v3.3.0 // indirect; indirec
 	github.com/breml/errchkjson v0.2.3 // indirect
 	github.com/butuzov/ireturn v0.1.1 // indirect
-	github.com/cenkalti/backoff/v4 v4.1.3 // indirect
+	github.com/cenkalti/backoff/v4 v4.1.3
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/charithe/durationcheck v0.0.9 // indirect
 	github.com/chavacava/garif v0.0.0-20210405164556-e8a0a408d6af // indirect

--- a/internal/core/state.go
+++ b/internal/core/state.go
@@ -1,0 +1,8 @@
+package core
+
+type WorkflowInstanceState int
+
+const (
+	WorkflowInstanceStateActive WorkflowInstanceState = iota
+	WorkflowInstanceStateFinished
+)

--- a/internal/task/workflow.go
+++ b/internal/task/workflow.go
@@ -12,6 +12,8 @@ type Workflow struct {
 	// WorkflowInstance is the workflow instance that this task is for
 	WorkflowInstance *core.WorkflowInstance
 
+	WorkflowInstanceState core.WorkflowInstanceState
+
 	Metadata *core.WorkflowMetadata
 
 	// LastSequenceID is the sequence ID of the newest event in the workflow instances's history

--- a/internal/worker/activity.go
+++ b/internal/worker/activity.go
@@ -58,6 +58,8 @@ func (aw *activityWorker) Start(ctx context.Context) error {
 }
 
 func (aw *activityWorker) WaitForCompletion() error {
+	close(aw.activityTaskQueue)
+
 	aw.wg.Wait()
 
 	return nil

--- a/internal/worker/workflow.go
+++ b/internal/worker/workflow.go
@@ -72,6 +72,8 @@ func (ww *workflowWorker) Start(ctx context.Context) error {
 }
 
 func (ww *workflowWorker) WaitForCompletion() error {
+	close(ww.workflowTaskQueue)
+
 	ww.wg.Wait()
 
 	return nil

--- a/internal/worker/workflow.go
+++ b/internal/worker/workflow.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/benbjohnson/clock"
 	"github.com/cschleiden/go-workflows/backend"
+	"github.com/cschleiden/go-workflows/internal/core"
 	"github.com/cschleiden/go-workflows/internal/task"
 	"github.com/cschleiden/go-workflows/internal/workflow"
 	"github.com/cschleiden/go-workflows/internal/workflow/cache"
@@ -132,14 +133,14 @@ func (ww *workflowWorker) handle(ctx context.Context, t *task.Workflow) {
 		ww.logger.Panic("could not handle workflow task", "error", err)
 	}
 
-	state := backend.WorkflowStateActive
+	state := core.WorkflowInstanceStateActive
 	if result.Completed {
-		state = backend.WorkflowStateFinished
+		state = core.WorkflowInstanceStateFinished
 	}
 
 	if err := ww.backend.CompleteWorkflowTask(
 		ctx, t, t.WorkflowInstance, state, result.Executed, result.ActivityEvents, result.TimerEvents, result.WorkflowEvents); err != nil {
-		ww.logger.Panic("Could not complete workflow task", "error", err)
+		ww.logger.Panic("could not complete workflow task", "error", err)
 	}
 }
 

--- a/internal/workflow/executor.go
+++ b/internal/workflow/executor.go
@@ -99,6 +99,18 @@ func (e *executor) ExecuteTask(ctx context.Context, t *task.Workflow) (*Executio
 
 	logger.Debug("Executing workflow task", "task_last_sequence_id", t.LastSequenceID)
 
+	if t.WorkflowInstanceState == core.WorkflowInstanceStateFinished {
+		// This should never happen. For now, log information and then panic.
+		logger.Debug("Received workflow task for finished workflow instance, discarding events")
+
+		// Log events that caused this task to be scheduled
+		for _, event := range t.NewEvents {
+			logger.Debug("Discarded event:", "id", event.ID, "event_type", event.Type.String(), "schedule_event_id", event.ScheduleEventID)
+		}
+
+		return &ExecutionResult{}, nil
+	}
+
 	skipNewEvents := false
 
 	if t.LastSequenceID > e.lastSequenceID {

--- a/internal/workflow/executor.go
+++ b/internal/workflow/executor.go
@@ -195,7 +195,7 @@ func (e *executor) replayHistory(history []history.Event) error {
 	e.workflowState.SetReplaying(true)
 	for _, event := range history {
 		if event.SequenceID < e.lastSequenceID {
-			panic("history has older events than current state")
+			e.logger.Panic("history has older events than current state")
 		}
 
 		if err := e.executeEvent(event); err != nil {
@@ -220,7 +220,7 @@ func (e *executor) executeNewEvents(newEvents []history.Event) ([]history.Event,
 	if e.workflow.Completed() {
 		// TODO: Is this too early? We haven't committed some of the commands
 		if e.workflowState.HasPendingFutures() {
-			panic("Workflow completed, but there are still pending futures")
+			e.logger.Panic("workflow completed, but there are still pending futures")
 		}
 
 		e.workflowCompleted(e.workflow.Result(), e.workflow.Error())


### PR DESCRIPTION
Instead of `panic`ing when dequeuing a workflow task with new events for an already completed instance, this will instead log the events and discard them. 

There are valid scenarios where events might get delivered to an already completed instance, like workflow instances sending events to each other. We cannot fail in this case, and the destination instance might already be completed when the source instance completes its workflow task.

In the future we might want to wake up the instance again or have other behavior to handle those kinds of signals, for now we assume that those signals aren't important. 