### PR TITLE
Metrics

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cschleiden/go-workflows/internal/history"
 	"github.com/cschleiden/go-workflows/internal/task"
 	"github.com/cschleiden/go-workflows/log"
+	"github.com/cschleiden/go-workflows/metrics"
 	"github.com/cschleiden/go-workflows/workflow"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -62,6 +63,9 @@ type Backend interface {
 	// Logger returns the configured logger for the backend
 	Logger() log.Logger
 
-	// Tracer returns th configured trace provider for the backend
+	// Tracer returns the configured trace provider for the backend
 	Tracer() trace.Tracer
+
+	// Metrics returns the configured metrics client for the backend
+	Metrics() metrics.Client
 }

--- a/backend/mock_Backend.go
+++ b/backend/mock_Backend.go
@@ -10,6 +10,8 @@ import (
 
 	log "github.com/cschleiden/go-workflows/log"
 
+	metrics "github.com/cschleiden/go-workflows/metrics"
+
 	mock "github.com/stretchr/testify/mock"
 
 	task "github.com/cschleiden/go-workflows/internal/task"
@@ -51,8 +53,7 @@ func (_m *MockBackend) CompleteActivityTask(ctx context.Context, instance *core.
 }
 
 // CompleteWorkflowTask provides a mock function with given fields: ctx, _a1, instance, state, executedEvents, activityEvents, timerEvents, workflowEvents
-func (_m *MockBackend) CompleteWorkflowTask(
-	ctx context.Context, _a1 *task.Workflow, instance *core.WorkflowInstance, state core.WorkflowInstanceState, executedEvents []history.Event, activityEvents []history.Event, timerEvents []history.Event, workflowEvents []history.WorkflowEvent) error {
+func (_m *MockBackend) CompleteWorkflowTask(ctx context.Context, _a1 *task.Workflow, instance *core.WorkflowInstance, state core.WorkflowInstanceState, executedEvents []history.Event, activityEvents []history.Event, timerEvents []history.Event, workflowEvents []history.WorkflowEvent) error {
 	ret := _m.Called(ctx, _a1, instance, state, executedEvents, activityEvents, timerEvents, workflowEvents)
 
 	var r0 error
@@ -207,6 +208,22 @@ func (_m *MockBackend) Logger() log.Logger {
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(log.Logger)
+		}
+	}
+
+	return r0
+}
+
+// Metrics provides a mock function with given fields:
+func (_m *MockBackend) Metrics() metrics.Client {
+	ret := _m.Called()
+
+	var r0 metrics.Client
+	if rf, ok := ret.Get(0).(func() metrics.Client); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(metrics.Client)
 		}
 	}
 

--- a/backend/mysql/mysql.go
+++ b/backend/mysql/mysql.go
@@ -13,7 +13,7 @@ import (
 	"github.com/cschleiden/go-workflows/backend"
 	"github.com/cschleiden/go-workflows/internal/core"
 	"github.com/cschleiden/go-workflows/internal/history"
-	mi "github.com/cschleiden/go-workflows/internal/metrics"
+	"github.com/cschleiden/go-workflows/internal/metrickeys"
 	"github.com/cschleiden/go-workflows/internal/task"
 	"github.com/cschleiden/go-workflows/log"
 	"github.com/cschleiden/go-workflows/metrics"
@@ -97,7 +97,7 @@ func (b *mysqlBackend) Tracer() trace.Tracer {
 }
 
 func (b *mysqlBackend) Metrics() metrics.Client {
-	return b.options.Metrics.WithTags(metrics.Tags{mi.Backend: "mysql"})
+	return b.options.Metrics.WithTags(metrics.Tags{metrickeys.Backend: "mysql"})
 }
 
 func (b *mysqlBackend) CancelWorkflowInstance(ctx context.Context, instance *workflow.Instance, event *history.Event) error {

--- a/backend/mysql/mysql.go
+++ b/backend/mysql/mysql.go
@@ -13,8 +13,10 @@ import (
 	"github.com/cschleiden/go-workflows/backend"
 	"github.com/cschleiden/go-workflows/internal/core"
 	"github.com/cschleiden/go-workflows/internal/history"
+	mi "github.com/cschleiden/go-workflows/internal/metrics"
 	"github.com/cschleiden/go-workflows/internal/task"
 	"github.com/cschleiden/go-workflows/log"
+	"github.com/cschleiden/go-workflows/metrics"
 	"github.com/cschleiden/go-workflows/workflow"
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/google/uuid"
@@ -92,6 +94,10 @@ func (b *mysqlBackend) Logger() log.Logger {
 
 func (b *mysqlBackend) Tracer() trace.Tracer {
 	return b.options.TracerProvider.Tracer(backend.TracerName)
+}
+
+func (b *mysqlBackend) Metrics() metrics.Client {
+	return b.options.Metrics.WithTags(metrics.Tags{mi.Backend: "mysql"})
 }
 
 func (b *mysqlBackend) CancelWorkflowInstance(ctx context.Context, instance *workflow.Instance, event *history.Event) error {

--- a/backend/options.go
+++ b/backend/options.go
@@ -4,12 +4,16 @@ import (
 	"time"
 
 	"github.com/cschleiden/go-workflows/internal/logger"
+	mi "github.com/cschleiden/go-workflows/internal/metrics"
 	"github.com/cschleiden/go-workflows/log"
+	"github.com/cschleiden/go-workflows/metrics"
 	"go.opentelemetry.io/otel/trace"
 )
 
 type Options struct {
 	Logger log.Logger
+
+	Metrics metrics.Client
 
 	TracerProvider trace.TracerProvider
 
@@ -26,6 +30,7 @@ var DefaultOptions Options = Options{
 	ActivityLockTimeout: time.Minute * 2,
 
 	Logger:         logger.NewDefaultLogger(),
+	Metrics:        mi.NewNoopMetricsClient(),
 	TracerProvider: trace.NewNoopTracerProvider(),
 }
 
@@ -40,6 +45,12 @@ func WithStickyTimeout(timeout time.Duration) BackendOption {
 func WithLogger(logger log.Logger) BackendOption {
 	return func(o *Options) {
 		o.Logger = logger
+	}
+}
+
+func WithMetrics(client metrics.Client) BackendOption {
+	return func(o *Options) {
+		o.Metrics = client
 	}
 }
 

--- a/backend/redis/redis.go
+++ b/backend/redis/redis.go
@@ -8,7 +8,7 @@ import (
 	"github.com/cschleiden/go-workflows/backend"
 	"github.com/cschleiden/go-workflows/internal/core"
 	"github.com/cschleiden/go-workflows/internal/history"
-	mi "github.com/cschleiden/go-workflows/internal/metrics"
+	"github.com/cschleiden/go-workflows/internal/metrickeys"
 	"github.com/cschleiden/go-workflows/log"
 	"github.com/cschleiden/go-workflows/metrics"
 	"github.com/go-redis/redis/v8"
@@ -109,7 +109,7 @@ func (rb *redisBackend) Logger() log.Logger {
 }
 
 func (rb *redisBackend) Metrics() metrics.Client {
-	return rb.options.Metrics.WithTags(metrics.Tags{mi.Backend: "mysql"})
+	return rb.options.Metrics.WithTags(metrics.Tags{metrickeys.Backend: "redis"})
 }
 
 func (rb *redisBackend) Tracer() trace.Tracer {

--- a/backend/redis/redis.go
+++ b/backend/redis/redis.go
@@ -8,7 +8,9 @@ import (
 	"github.com/cschleiden/go-workflows/backend"
 	"github.com/cschleiden/go-workflows/internal/core"
 	"github.com/cschleiden/go-workflows/internal/history"
+	mi "github.com/cschleiden/go-workflows/internal/metrics"
 	"github.com/cschleiden/go-workflows/log"
+	"github.com/cschleiden/go-workflows/metrics"
 	"github.com/go-redis/redis/v8"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -104,6 +106,10 @@ type activityData struct {
 
 func (rb *redisBackend) Logger() log.Logger {
 	return rb.options.Logger
+}
+
+func (rb *redisBackend) Metrics() metrics.Client {
+	return rb.options.Metrics.WithTags(metrics.Tags{mi.Backend: "mysql"})
 }
 
 func (rb *redisBackend) Tracer() trace.Tracer {

--- a/backend/sqlite/sqlite.go
+++ b/backend/sqlite/sqlite.go
@@ -13,7 +13,7 @@ import (
 	"github.com/cschleiden/go-workflows/backend"
 	"github.com/cschleiden/go-workflows/internal/core"
 	"github.com/cschleiden/go-workflows/internal/history"
-	mi "github.com/cschleiden/go-workflows/internal/metrics"
+	"github.com/cschleiden/go-workflows/internal/metrickeys"
 	"github.com/cschleiden/go-workflows/internal/task"
 	"github.com/cschleiden/go-workflows/log"
 	"github.com/cschleiden/go-workflows/metrics"
@@ -68,7 +68,7 @@ func (sb *sqliteBackend) Logger() log.Logger {
 }
 
 func (sb *sqliteBackend) Metrics() metrics.Client {
-	return sb.options.Metrics.WithTags(metrics.Tags{mi.Backend: "mysql"})
+	return sb.options.Metrics.WithTags(metrics.Tags{metrickeys.Backend: "sqlite"})
 }
 
 func (sb *sqliteBackend) Tracer() trace.Tracer {

--- a/backend/sqlite/sqlite.go
+++ b/backend/sqlite/sqlite.go
@@ -13,8 +13,10 @@ import (
 	"github.com/cschleiden/go-workflows/backend"
 	"github.com/cschleiden/go-workflows/internal/core"
 	"github.com/cschleiden/go-workflows/internal/history"
+	mi "github.com/cschleiden/go-workflows/internal/metrics"
 	"github.com/cschleiden/go-workflows/internal/task"
 	"github.com/cschleiden/go-workflows/log"
+	"github.com/cschleiden/go-workflows/metrics"
 	"github.com/cschleiden/go-workflows/workflow"
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/trace"
@@ -63,6 +65,10 @@ type sqliteBackend struct {
 
 func (sb *sqliteBackend) Logger() log.Logger {
 	return sb.options.Logger
+}
+
+func (sb *sqliteBackend) Metrics() metrics.Client {
+	return sb.options.Metrics.WithTags(metrics.Tags{mi.Backend: "mysql"})
 }
 
 func (sb *sqliteBackend) Tracer() trace.Tracer {

--- a/client/client.go
+++ b/client/client.go
@@ -14,7 +14,9 @@ import (
 	"github.com/cschleiden/go-workflows/internal/core"
 	"github.com/cschleiden/go-workflows/internal/fn"
 	"github.com/cschleiden/go-workflows/internal/history"
+	"github.com/cschleiden/go-workflows/internal/metrickeys"
 	"github.com/cschleiden/go-workflows/internal/tracing"
+	"github.com/cschleiden/go-workflows/metrics"
 	"github.com/cschleiden/go-workflows/workflow"
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/attribute"
@@ -87,6 +89,8 @@ func (c *client) CreateWorkflowInstance(ctx context.Context, options WorkflowIns
 	}
 
 	c.backend.Logger().Debug("Created workflow instance", "instance_id", wfi.InstanceID, "execution_id", wfi.ExecutionID)
+
+	c.backend.Metrics().Counter(metrickeys.WorkflowInstanceCreated, metrics.Tags{}, 1)
 
 	return wfi, nil
 }

--- a/internal/metrickeys/metrickeys.go
+++ b/internal/metrickeys/metrickeys.go
@@ -1,0 +1,32 @@
+package metrickeys
+
+const (
+	Prefix = "workflows."
+
+	// Workflows
+	WorkflowInstanceCreated  = Prefix + "workflow.created"
+	WorkflowInstanceFinished = Prefix + "workflow.finished"
+
+	WorkflowTaskScheduled = Prefix + "workflow.task.scheduled"
+	WorkflowTaskProcessed = Prefix + "workflow.task.processed"
+	WorkflowTaskDelay     = Prefix + "workflow.task.time_in_queue"
+
+	WorkflowInstanceCacheSize     = Prefix + "workflow.cache.size"
+	WorkflowInstanceCacheEviction = Prefix + "workflow.cache.eviction"
+
+	// Activities
+	ActivityTaskScheduled = Prefix + "activity.task.scheduled"
+	ActivityTaskProcessed = Prefix + "activity.task.processed"
+	ActivityTaskDelay     = Prefix + "activity.task.time_in_queue"
+)
+
+// Tag names
+const (
+	// Backend being used
+	Backend = "backend"
+
+	// Reason for evicting an entry from the workflow instance cache
+	EvictionReason = "reason"
+
+	ActivityName = "activity"
+)

--- a/internal/metrics/noop.go
+++ b/internal/metrics/noop.go
@@ -3,7 +3,7 @@ package metrics
 import (
 	"time"
 
-	m "github.com/cschleiden/go-workflows/metrics"
+	"github.com/cschleiden/go-workflows/metrics"
 )
 
 type noopMetricsClient struct {
@@ -13,20 +13,21 @@ func NewNoopMetricsClient() *noopMetricsClient {
 	return &noopMetricsClient{}
 }
 
-var _ m.Client = (*noopMetricsClient)(nil)
+var _ metrics.Client = (*noopMetricsClient)(nil)
 
-func (*noopMetricsClient) Counter(name string, tags m.Tags, value float64) {
+func (*noopMetricsClient) Counter(name string, tags metrics.Tags, value int64) {
 }
 
-// Distribution implements metrics.Client
-func (*noopMetricsClient) Distribution(name string, tags m.Tags, value float64) {
+func (*noopMetricsClient) Distribution(name string, tags metrics.Tags, value float64) {
 }
 
-// Timing implements metrics.Client
-func (*noopMetricsClient) Timing(name string, tags m.Tags, duration time.Duration) {
+func (*noopMetricsClient) Gauge(name string, tags metrics.Tags, value int64) {
+
 }
 
-// WithTags implements metrics.Client
-func (nmc *noopMetricsClient) WithTags(tags m.Tags) m.Client {
+func (*noopMetricsClient) Timing(name string, tags metrics.Tags, duration time.Duration) {
+}
+
+func (nmc *noopMetricsClient) WithTags(tags metrics.Tags) metrics.Client {
 	return nmc
 }

--- a/internal/metrics/noop.go
+++ b/internal/metrics/noop.go
@@ -1,0 +1,32 @@
+package metrics
+
+import (
+	"time"
+
+	m "github.com/cschleiden/go-workflows/metrics"
+)
+
+type noopMetricsClient struct {
+}
+
+func NewNoopMetricsClient() *noopMetricsClient {
+	return &noopMetricsClient{}
+}
+
+var _ m.Client = (*noopMetricsClient)(nil)
+
+func (*noopMetricsClient) Counter(name string, tags m.Tags, value float64) {
+}
+
+// Distribution implements metrics.Client
+func (*noopMetricsClient) Distribution(name string, tags m.Tags, value float64) {
+}
+
+// Timing implements metrics.Client
+func (*noopMetricsClient) Timing(name string, tags m.Tags, duration time.Duration) {
+}
+
+// WithTags implements metrics.Client
+func (nmc *noopMetricsClient) WithTags(tags m.Tags) m.Client {
+	return nmc
+}

--- a/internal/worker/workflow.go
+++ b/internal/worker/workflow.go
@@ -15,13 +15,7 @@ import (
 	"github.com/cschleiden/go-workflows/log"
 )
 
-type WorkflowWorker interface {
-	Start(context.Context) error
-
-	WaitForCompletion() error
-}
-
-type workflowWorker struct {
+type WorkflowWorker struct {
 	backend backend.Backend
 
 	options *Options
@@ -37,7 +31,7 @@ type workflowWorker struct {
 	wg *sync.WaitGroup
 }
 
-func NewWorkflowWorker(backend backend.Backend, registry *workflow.Registry, options *Options) WorkflowWorker {
+func NewWorkflowWorker(backend backend.Backend, registry *workflow.Registry, options *Options) *WorkflowWorker {
 	var c workflow.ExecutorCache
 	if options.WorkflowExecutorCache != nil {
 		c = options.WorkflowExecutorCache
@@ -45,7 +39,7 @@ func NewWorkflowWorker(backend backend.Backend, registry *workflow.Registry, opt
 		c = cache.NewWorkflowExecutorLRUCache(options.WorkflowExecutorCacheSize, options.WorkflowExecutorCacheTTL)
 	}
 
-	return &workflowWorker{
+	return &WorkflowWorker{
 		backend: backend,
 
 		options: options,
@@ -61,7 +55,7 @@ func NewWorkflowWorker(backend backend.Backend, registry *workflow.Registry, opt
 	}
 }
 
-func (ww *workflowWorker) Start(ctx context.Context) error {
+func (ww *WorkflowWorker) Start(ctx context.Context) error {
 	for i := 0; i <= ww.options.WorkflowPollers; i++ {
 		go ww.runPoll(ctx)
 	}
@@ -71,7 +65,7 @@ func (ww *workflowWorker) Start(ctx context.Context) error {
 	return nil
 }
 
-func (ww *workflowWorker) WaitForCompletion() error {
+func (ww *WorkflowWorker) WaitForCompletion() error {
 	close(ww.workflowTaskQueue)
 
 	ww.wg.Wait()
@@ -79,7 +73,7 @@ func (ww *workflowWorker) WaitForCompletion() error {
 	return nil
 }
 
-func (ww *workflowWorker) runPoll(ctx context.Context) {
+func (ww *WorkflowWorker) runPoll(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
@@ -99,7 +93,7 @@ func (ww *workflowWorker) runPoll(ctx context.Context) {
 	}
 }
 
-func (ww *workflowWorker) runDispatcher() {
+func (ww *WorkflowWorker) runDispatcher() {
 	var sem chan (struct{})
 
 	if ww.options.MaxParallelWorkflowTasks > 0 {
@@ -128,7 +122,7 @@ func (ww *workflowWorker) runDispatcher() {
 	}
 }
 
-func (ww *workflowWorker) handle(ctx context.Context, t *task.Workflow) {
+func (ww *WorkflowWorker) handle(ctx context.Context, t *task.Workflow) {
 	result, err := ww.handleTask(ctx, t)
 	if err != nil {
 		ww.logger.Panic("could not handle workflow task", "error", err)
@@ -145,7 +139,7 @@ func (ww *workflowWorker) handle(ctx context.Context, t *task.Workflow) {
 	}
 }
 
-func (ww *workflowWorker) handleTask(
+func (ww *WorkflowWorker) handleTask(
 	ctx context.Context,
 	t *task.Workflow,
 ) (*workflow.ExecutionResult, error) {
@@ -169,7 +163,7 @@ func (ww *workflowWorker) handleTask(
 	return result, nil
 }
 
-func (ww *workflowWorker) getExecutor(ctx context.Context, t *task.Workflow) (workflow.WorkflowExecutor, error) {
+func (ww *WorkflowWorker) getExecutor(ctx context.Context, t *task.Workflow) (workflow.WorkflowExecutor, error) {
 	// Try to get a cached executor
 	executor, ok, err := ww.cache.Get(ctx, t.WorkflowInstance)
 	if err != nil {
@@ -192,7 +186,7 @@ func (ww *workflowWorker) getExecutor(ctx context.Context, t *task.Workflow) (wo
 	return executor, nil
 }
 
-func (ww *workflowWorker) heartbeatTask(ctx context.Context, task *task.Workflow) {
+func (ww *WorkflowWorker) heartbeatTask(ctx context.Context, task *task.Workflow) {
 	t := time.NewTicker(ww.options.WorkflowHeartbeatInterval)
 	defer t.Stop()
 
@@ -208,7 +202,7 @@ func (ww *workflowWorker) heartbeatTask(ctx context.Context, task *task.Workflow
 	}
 }
 
-func (ww *workflowWorker) poll(ctx context.Context, timeout time.Duration) (*task.Workflow, error) {
+func (ww *WorkflowWorker) poll(ctx context.Context, timeout time.Duration) (*task.Workflow, error) {
 	if timeout == 0 {
 		timeout = 30 * time.Second
 	}

--- a/internal/workflow/cache/cache.go
+++ b/internal/workflow/cache/cache.go
@@ -5,26 +5,41 @@ import (
 	"time"
 
 	"github.com/cschleiden/go-workflows/internal/core"
+	"github.com/cschleiden/go-workflows/internal/metrickeys"
 	"github.com/cschleiden/go-workflows/internal/workflow"
+	"github.com/cschleiden/go-workflows/metrics"
 	"github.com/jellydator/ttlcache/v3"
 )
 
 type LruCache struct {
-	c *ttlcache.Cache[string, workflow.WorkflowExecutor]
+	mc metrics.Client
+	c  *ttlcache.Cache[string, workflow.WorkflowExecutor]
 }
 
-func NewWorkflowExecutorLRUCache(size int, expiration time.Duration) workflow.ExecutorCache {
+func NewWorkflowExecutorLRUCache(mc metrics.Client, size int, expiration time.Duration) workflow.ExecutorCache {
 	c := ttlcache.New(
 		ttlcache.WithCapacity[string, workflow.WorkflowExecutor](uint64(size)),
 		ttlcache.WithTTL[string, workflow.WorkflowExecutor](expiration),
 	)
 
 	c.OnEviction(func(ctx context.Context, er ttlcache.EvictionReason, i *ttlcache.Item[string, workflow.WorkflowExecutor]) {
+		// Close the executor to allow it to clean up resources.
 		i.Value().Close()
+
+		reason := ""
+		switch er {
+		case ttlcache.EvictionReasonExpired:
+			reason = "expired"
+		case ttlcache.EvictionReasonCapacityReached:
+			reason = "capacity"
+		}
+
+		mc.Counter(metrickeys.WorkflowInstanceCacheEviction, metrics.Tags{metrickeys.EvictionReason: reason}, 1)
 	})
 
 	return &LruCache{
-		c: c,
+		mc: mc,
+		c:  c,
 	}
 }
 
@@ -39,6 +54,8 @@ func (lc *LruCache) Get(ctx context.Context, instance *core.WorkflowInstance) (w
 
 func (lc *LruCache) Store(ctx context.Context, instance *core.WorkflowInstance, executor workflow.WorkflowExecutor) error {
 	lc.c.Set(getKey(instance), executor, ttlcache.DefaultTTL)
+
+	lc.mc.Gauge(metrickeys.WorkflowInstanceCacheSize, metrics.Tags{}, int64(lc.c.Len()))
 
 	return nil
 }

--- a/internal/workflow/cache/cache_test.go
+++ b/internal/workflow/cache/cache_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cschleiden/go-workflows/internal/core"
 	"github.com/cschleiden/go-workflows/internal/history"
 	"github.com/cschleiden/go-workflows/internal/logger"
+	"github.com/cschleiden/go-workflows/internal/metrics"
 	wf "github.com/cschleiden/go-workflows/internal/workflow"
 	"github.com/cschleiden/go-workflows/workflow"
 	"github.com/stretchr/testify/require"
@@ -18,7 +19,7 @@ import (
 )
 
 func Test_Cache_StoreAndGet(t *testing.T) {
-	c := NewWorkflowExecutorLRUCache(1, time.Second*10)
+	c := NewWorkflowExecutorLRUCache(metrics.NewNoopMetricsClient(), 1, time.Second*10)
 
 	r := wf.NewRegistry()
 	r.RegisterWorkflow(workflowWithActivity)
@@ -51,7 +52,9 @@ func Test_Cache_StoreAndGet(t *testing.T) {
 }
 
 func Test_Cache_Evict(t *testing.T) {
-	c := NewWorkflowExecutorLRUCache(128,
+	c := NewWorkflowExecutorLRUCache(
+		metrics.NewNoopMetricsClient(),
+		128,
 		1, // Should evict immediately
 	)
 

--- a/internal/workflow/executor.go
+++ b/internal/workflow/executor.go
@@ -101,7 +101,7 @@ func (e *executor) ExecuteTask(ctx context.Context, t *task.Workflow) (*Executio
 
 	if t.WorkflowInstanceState == core.WorkflowInstanceStateFinished {
 		// This should never happen. For now, log information and then panic.
-		logger.Debug("Received workflow task for finished workflow instance, discarding events")
+		logger.Error("Received workflow task for finished workflow instance, discarding events")
 
 		// Log events that caused this task to be scheduled
 		for _, event := range t.NewEvents {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -1,0 +1,15 @@
+package metrics
+
+import "time"
+
+type Tags map[string]string
+
+type Client interface {
+	Counter(name string, tags Tags, value float64)
+
+	Distribution(name string, tags Tags, value float64)
+
+	Timing(name string, tags Tags, duration time.Duration)
+
+	WithTags(tags Tags) Client
+}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -5,9 +5,11 @@ import "time"
 type Tags map[string]string
 
 type Client interface {
-	Counter(name string, tags Tags, value float64)
+	Counter(name string, tags Tags, value int64)
 
 	Distribution(name string, tags Tags, value float64)
+
+	Gauge(name string, tags Tags, value int64)
 
 	Timing(name string, tags Tags, duration time.Duration)
 

--- a/metrics/timer.go
+++ b/metrics/timer.go
@@ -1,0 +1,27 @@
+package metrics
+
+import (
+	"time"
+)
+
+type timer struct {
+	client Client
+	start  time.Time
+	name   string
+	tags   Tags
+}
+
+func Timer(client Client, name string, tags Tags) *timer {
+	return &timer{
+		client: client,
+		start:  time.Now(),
+		name:   name,
+		tags:   tags,
+	}
+}
+
+// Stop the timer and send the elapsed time as milliseconds as a distribution metric
+func (t *timer) Stop() {
+	elapsed := time.Since(t.start)
+	t.client.Distribution(t.name, t.tags, float64(elapsed/time.Millisecond))
+}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/benbjohnson/clock"
@@ -45,8 +46,8 @@ type worker struct {
 
 	registry *workflowinternal.Registry
 
-	workflowWorker internal.WorkflowWorker
-	activityWorker internal.ActivityWorker
+	workflowWorker *internal.WorkflowWorker
+	activityWorker *internal.ActivityWorker
 
 	workflows  map[string]interface{}
 	activities map[string]interface{}
@@ -85,8 +86,13 @@ func New(backend backend.Backend, options *Options) Worker {
 }
 
 func (w *worker) Start(ctx context.Context) error {
-	w.workflowWorker.Start(ctx)
-	w.activityWorker.Start(ctx)
+	if err := w.workflowWorker.Start(ctx); err != nil {
+		return fmt.Errorf("starting workflow worker: %w", err)
+	}
+
+	if err := w.activityWorker.Start(ctx); err != nil {
+		return fmt.Errorf("starting activity worker: %w", err)
+	}
 
 	return nil
 }

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -81,9 +81,6 @@ func New(backend backend.Backend, options *Options) Worker {
 		activityWorker: internal.NewActivityWorker(backend, registry, clock.New(), options),
 
 		registry: registry,
-
-		workflows:  map[string]interface{}{},
-		activities: map[string]interface{}{},
 	}
 }
 


### PR DESCRIPTION
This implements support for 

* [X] Distribution: activity task processing time `workflow.task.processed` (ms), tags: `activity` activity name
* [X] Distribution: workflow task processing time `workflow.task.processed` (ms)
* [X] Counter: `workflow.created`
* [X] Counter: `workflow.finished`
* [X] Distribution: `workflow.task.time_in_queue` (ms)
* [X] Distribution: `activity.task.time_in_queue` (ms), tags: `activity` activity name
* [X] Counter: activity scheduled `activity.task.scheduled`
* [X] Gauge: executor cache size: `workflow.cache.size`
* [X] Counter: executor cache eviction `workflow.cache.eviction`

Doc updates will follow later.

Contributes to #57 