### PR TITLE
Fix out of order events bug + add test

### DIFF
--- a/internal/workflow/executor.go
+++ b/internal/workflow/executor.go
@@ -40,17 +40,18 @@ type WorkflowExecutor interface {
 }
 
 type executor struct {
-	registry          *Registry
-	historyProvider   WorkflowHistoryProvider
-	workflow          *workflow
-	workflowTracer    *workflowtracer.WorkflowTracer
-	workflowState     *workflowstate.WfState
-	workflowCtx       sync.Context
-	workflowCtxCancel sync.CancelFunc
-	clock             clock.Clock
-	logger            log.Logger
-	tracer            trace.Tracer
-	lastSequenceID    int64
+	registry           *Registry
+	historyProvider    WorkflowHistoryProvider
+	workflow           *workflow
+	workflowTracer     *workflowtracer.WorkflowTracer
+	workflowState      *workflowstate.WfState
+	workflowCtx        sync.Context
+	workflowCtxCancel  sync.CancelFunc
+	clock              clock.Clock
+	logger             log.Logger
+	tracer             trace.Tracer
+	lastSequenceID     int64
+	wfStartedEventSeen bool
 }
 
 func NewExecutor(logger log.Logger, tracer trace.Tracer, registry *Registry, historyProvider WorkflowHistoryProvider, instance *core.WorkflowInstance, clock clock.Clock) (WorkflowExecutor, error) {
@@ -69,15 +70,16 @@ func NewExecutor(logger log.Logger, tracer trace.Tracer, registry *Registry, his
 	)
 
 	return &executor{
-		registry:          registry,
-		historyProvider:   historyProvider,
-		workflowTracer:    wfTracer,
-		workflowState:     s,
-		workflowCtx:       wfCtx,
-		workflowCtxCancel: cancel,
-		clock:             clock,
-		logger:            logger,
-		tracer:            tracer,
+		registry:           registry,
+		historyProvider:    historyProvider,
+		workflowTracer:     wfTracer,
+		workflowState:      s,
+		workflowCtx:        wfCtx,
+		workflowCtxCancel:  cancel,
+		clock:              clock,
+		logger:             logger,
+		tracer:             tracer,
+		wfStartedEventSeen: false,
 	}, nil
 }
 
@@ -139,6 +141,36 @@ func (e *executor) ExecuteTask(ctx context.Context, t *task.Workflow) (*Executio
 		}
 	} else if t.LastSequenceID < e.lastSequenceID {
 		return nil, fmt.Errorf("task has older history than current state, cannot execute")
+	}
+
+	// Potentially reorder new events here, protecting against
+	// cases in which new events are received for a workflow instance
+	// before the scheduler for that workflow instance has been
+	// created. To reorder, we find the WorkflowExecutionStarted
+	// event, then move it to the first position in t.NewEvents.
+	// t.NewEvents is modified in-place.
+	// See: https://github.com/cschleiden/go-workflows/issues/143
+	if !e.wfStartedEventSeen {
+		for i, ev := range t.NewEvents {
+			if ev.Type == history.EventType_WorkflowExecutionStarted {
+				if i > 0 {
+					// Shift elements before the WorkflowExecutionStarted
+					// event 1 index right, making space at index 0 to reinsert
+					// the WorkflowExecutionStarted event. Shifting instead of
+					// re-slicing and calling append() twice, i.e.:
+					// 		t.NewEvents = append(t.NewEvents[0:i], t.NewEvents[i+1:]...)
+					//		t.NewEvents = append([]history.Event{ev}, t.NewEvents...)
+					// is faster and avoids the possibility of copying
+					// slices if t.NewEvents is large
+					for j := i; j >= 1; j-- {
+						t.NewEvents[j] = t.NewEvents[j-1]
+					}
+					t.NewEvents[0] = ev
+				}
+				e.wfStartedEventSeen = true
+				break
+			}
+		}
 	}
 
 	// Always add a WorkflowTaskStarted event before executing new tasks
@@ -205,15 +237,23 @@ func (e *executor) ExecuteTask(ctx context.Context, t *task.Workflow) (*Executio
 	}, nil
 }
 
-func (e *executor) replayHistory(history []history.Event) error {
+func (e *executor) replayHistory(h []history.Event) error {
 	e.workflowState.SetReplaying(true)
-	for _, event := range history {
+	for _, event := range h {
 		if event.SequenceID < e.lastSequenceID {
 			e.logger.Panic("history has older events than current state")
 		}
 
 		if err := e.executeEvent(event); err != nil {
 			return err
+		}
+
+		// If we need to replay history before continuing execution of
+		// a new task, the executor must know if WorkflowExecutionStarted
+		// was seen during replay so it can determine if events should
+		// be reordered before it starts executing events for the new task
+		if event.Type == history.EventType_WorkflowExecutionStarted {
+			e.wfStartedEventSeen = true
 		}
 
 		e.lastSequenceID = event.SequenceID

--- a/internal/workflow/executor_test.go
+++ b/internal/workflow/executor_test.go
@@ -585,6 +585,57 @@ func Test_Executor(t *testing.T) {
 				require.True(t, e.workflow.Completed())
 			},
 		},
+		{
+			name: "Reorder events to protect against nil deref error",
+			f: func(t *testing.T, r *Registry, e *executor, i *core.WorkflowInstance, hp *testHistoryProvider) {
+				workflow := func(ctx wf.Context) error {
+					return nil
+				}
+
+				r.RegisterWorkflow(workflow)
+
+				// Input for signal
+				input, err := converter.DefaultConverter.To("<Insert signal arg here>")
+				if err != nil {
+					require.NoError(t, err)
+				}
+				// Create a SignalReceived event
+				signalReceivedEvent := history.NewPendingEvent(
+					time.Now(),
+					history.EventType_SignalReceived,
+					&history.SignalReceivedAttributes{
+						Name: fn.Name(workflow),
+						Arg:  input,
+					},
+				)
+
+				// Create a TimerFired event
+				timerFiredEvent := history.NewPendingEvent(
+					time.Now(),
+					history.EventType_TimerFired,
+					&history.TimerFiredAttributes{
+						At: time.Now().Add(time.Second),
+					},
+				)
+
+				task := startWorkflowTask("instanceID", workflow)
+				// Here, we reorder the history so that the WorkflowExecutionStarted
+				// event does not appear first. This simulates the condition that caused
+				// the bug previously. To do so, we insert two events in front of the
+				// WorkflowExecutionStarted event.
+				require.False(t, e.wfStartedEventSeen)
+				task.NewEvents = append([]history.Event{signalReceivedEvent, timerFiredEvent}, task.NewEvents...)
+				result, err := e.ExecuteTask(context.Background(), task)
+				require.True(t, e.wfStartedEventSeen)
+				require.NoError(t, err)
+				require.NoError(t, e.workflow.err)
+				require.Len(t, result.Executed, 5)
+				// verify the events were executed in the reordered order
+				require.Equal(t, history.EventType_WorkflowExecutionStarted, result.Executed[1].Type)
+				require.Equal(t, history.EventType_SignalReceived, result.Executed[2].Type)
+				require.Equal(t, history.EventType_TimerFired, result.Executed[3].Type)
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
# Description
This PR modifies  the `executor` to be aware of whether or not it has seen a `WorkflowExecutionStarted` event while executing tasks for the workflow instance it is associated with. 
  ```diff
 type executor struct {
  + wfStartedEventSeen bool
}
  ```
If it has seen this event previously, execution continues as normal. If it _hasn't_ seen the event previously, it checks through the events in the current task prior to executing any of them. If one of those events is `WorkflowExecutionStarted`, it shifts that event to the front of `t.NewEvents`, ensuring that `WorkflowExecutionStarted` is processed immediately after the `WorkflowTaskStarted` event. This in turn ensures that the `Scheduler` the workflow struct contains is never `nil`, preventing the `nil` pointer dereference error described in issue #143.

This PR also adds a test inside of `executor_test.go` to verify the event reordering/shifting behavior.

# Details on Approach
The core logic for shifting events is contained below:

  ```go
  for i, ev := range t.NewEvents {
	    if ev.Type == history.EventType_WorkflowExecutionStarted {
		    if i > 0 {
			    for j := i; j >= 1; j-- {
				    t.NewEvents[j] = t.NewEvents[j-1]
			    }
			    t.NewEvents[0] = ev
		    }
		    e.wfStartedEventSeen = true
		    break
	    }
}
  ```

`t.NewEvents` is modified in-place by shifting values over, as opposed to using `append()`. It's faster (about 2.5x from my testing) to shift values as opposed to an `append()`-based approach like the following, which might lead to new allocations if `t.NewEvents` is sufficiently large:

```golang
t.NewEvents = append(t.NewEvents[0:i], t.NewEvents[i+1:]...)
t.NewEvents = append([]history.Event{ev}, t.NewEvents...)
```

### Why add a field to `executor`?
If we're executing a new task for `WorkflowA` and the executor hasn't seen `WorkflowTaskStarted` yet, one of the events contained in the current task _must_ be `WorkflowTaskStarted`. In fact, I think the "current" task must be the first task for that particular workflow instance's executor. Why? If this weren't the case, the executor for `WorkflowA` would have errored out when executing a previous task, because processing that task's events would've relied on calling `e.workflow.Continue()`, which in turn relies on a `Scheduler`, which would've been `nil`. But, once we _know_ we've seen a `WorkflowExecutionStarted` event (either in the current task or previous ones), we won't need to preventatively reorder workflow events again for _this_ workflow instance, as we can be sure that `Scheduler` is not `nil`. So, a `bool` lets us avoid potentially iterating over and shifting events after we've done so the first time, enhancing performance if `t.NewEvents` is large.

### What about replays?
In the case of replays, I add a basic check inside of `replayHistory` for the `WorkflowStartedEvent`, which puts the executor in the right state for once it finishes replaying and starts executing the new task.
```golang
if event.Type == history.EventType_WorkflowExecutionStarted {
	e.wfStartedEventSeen = true
}
```

### Implications + Next Steps
It _is_ still possible that workflow instance `WorkflowA` could generate a disordered series of events for _another_ workflow instance `WorkflowB`, but because `WorkflowB`'s executor modifies event order _before_ those events are executed, the events will be reordered appropriately. This means that the history for the _calling_ workflow instance will look disordered (e.g. `SignalRequested --> SubWorkflowScheduled`), but the history belonging to the _actual_ instance will be correct (e.g. `WorkflowExecutionStarted --> SignalReceived`). **I didn't include a fix for "patching" the calling workflow's history in this case, since I wasn't sure if that was desired (it's not needed to fix the bug), but if you want to discuss that, I'm happy to!** 😄 

# Test Output Verification
Test Command: 
```
go test -v -run ^Test_Executor/Reorder_events_to_protect_against_nil_deref_error ./internal/workflow/
```

## Test Run without the fix
```
=== RUN   Test_Executor
=== RUN   Test_Executor/Reorder_events_to_protect_against_nil_deref_error
2022/12/02 15:29:43 DEBUG Executing workflow task task_id=579e7f37-37ae-4ccb-8952-f922a3081d29 instance_id=instanceID task_last_sequence_id=0
2022/12/02 15:29:43 DEBUG Executing event instance_id=2efb831b-7eeb-4220-83b7-55c589e13448 event_id=bd2edc6b-312b-4e35-86a9-39fee758486d seq_id=0 event_type=WorkflowTaskStarted schedule_event_id=0 is_replaying=false
2022/12/02 15:29:43 DEBUG Executing event instance_id=2efb831b-7eeb-4220-83b7-55c589e13448 event_id=05b44ea9-20a1-47a9-92d6-6b6a267568d3 seq_id=0 event_type=SignalReceived schedule_event_id=0 is_replaying=false
--- FAIL: Test_Executor (0.00s)
    --- FAIL: Test_Executor/Reorder_events_to_protect_against_nil_deref_error (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x102830614]

goroutine 7 [running]:
testing.tRunner.func1.2({0x1028e5140, 0x102aed7f0})
        /opt/homebrew/Cellar/go/1.18.4/libexec/src/testing/testing.go:1389 +0x1c8
testing.tRunner.func1()
        /opt/homebrew/Cellar/go/1.18.4/libexec/src/testing/testing.go:1392 +0x384
panic({0x1028e5140, 0x102aed7f0})
        /opt/homebrew/Cellar/go/1.18.4/libexec/src/runtime/panic.go:838 +0x204
github.com/cschleiden/go-workflows/internal/workflow.(*workflow).Continue(...)
        /Users/zaataylor/Documents/go-workflows/internal/workflow/workflow.go:88
github.com/cschleiden/go-workflows/internal/workflow.(*executor).handleSignalReceived(0x1400013a090, {{0x1400001a7b0, 0x24}, 0x0, 0x10, {0xc0dab5edd2b5bfc8, 0x3789f0, 0x102af9560}, 0x0, {0x1028c2e20, ...}, ...}, ...)
        /Users/zaataylor/Documents/go-workflows/internal/workflow/executor.go:633 +0x74
github.com/cschleiden/go-workflows/internal/workflow.(*executor).executeEvent(0x1400013a090, {{0x1400001a7b0, 0x24}, 0x0, 0x10, {0xc0dab5edd2b5bfc8, 0x3789f0, 0x102af9560}, 0x0, {0x1028c2e20, ...}, ...})
        /Users/zaataylor/Documents/go-workflows/internal/workflow/executor.go:339 +0x81c
github.com/cschleiden/go-workflows/internal/workflow.(*executor).executeNewEvents(0x1400013a090, {0x1400015a9a0, 0x4, 0x4})
        /Users/zaataylor/Documents/go-workflows/internal/workflow/executor.go:269 +0x158
github.com/cschleiden/go-workflows/internal/workflow.(*executor).ExecuteTask(0x1400013a090, {0x102934c90?, 0x14000018080?}, 0x14000012660)
        /Users/zaataylor/Documents/go-workflows/internal/workflow/executor.go:185 +0xbf4
github.com/cschleiden/go-workflows/internal/workflow.Test_Executor.func12(0x1400004e718?, 0x1026356b4?, 0x1400013a090, 0x1400000e330?, 0x2dd3125e273?)
        /Users/zaataylor/Documents/go-workflows/internal/workflow/executor_test.go:628 +0x4c4
github.com/cschleiden/go-workflows/internal/workflow.Test_Executor.func13(0x0?)
        /Users/zaataylor/Documents/go-workflows/internal/workflow/executor_test.go:648 +0x12c
testing.tRunner(0x1400011d520, 0x14000215710)
        /opt/homebrew/Cellar/go/1.18.4/libexec/src/testing/testing.go:1439 +0x110
created by testing.(*T).Run
        /opt/homebrew/Cellar/go/1.18.4/libexec/src/testing/testing.go:1486 +0x300
FAIL    github.com/cschleiden/go-workflows/internal/workflow    0.151s
FAIL
```
Notice that from the top few lines of output, the executor is executing the following events in this order (output truncated):
```
2022/12/02 15:29:43 DEBUG Executing event ... event_type=WorkflowTaskStarted schedule_event_id=0 is_replaying=false
2022/12/02 15:29:43 DEBUG Executing event ... event_type=SignalReceived schedule_event_id=0 is_replaying=false
```

1. `WorkflowTaskStarted` 😄 
2. `SignalReceived` 😭 ..._the problem_

## Test Run with the fix
```
=== RUN   Test_Executor
=== RUN   Test_Executor/Reorder_events_to_protect_against_nil_deref_error
2022/12/02 15:32:34 DEBUG Executing workflow task task_id=947f025b-863f-49eb-8f69-06fd018195c0 instance_id=instanceID task_last_sequence_id=0
2022/12/02 15:32:34 DEBUG Executing event instance_id=a72943ce-f8e6-42ad-a956-01fea93a3314 event_id=9b0ce0f8-9b65-45f6-a447-4ab4e275baf9 seq_id=0 event_type=WorkflowTaskStarted schedule_event_id=0 is_replaying=false
2022/12/02 15:32:34 DEBUG Executing event instance_id=a72943ce-f8e6-42ad-a956-01fea93a3314 event_id=acf42eea-4fe9-4133-ae35-d0c307ca0eeb seq_id=0 event_type=WorkflowExecutionStarted schedule_event_id=0 is_replaying=false
2022/12/02 15:32:34 DEBUG Executing event instance_id=a72943ce-f8e6-42ad-a956-01fea93a3314 event_id=f9fa409b-556d-419e-bf15-0f316e3142b2 seq_id=0 event_type=SignalReceived schedule_event_id=0 is_replaying=false
2022/12/02 15:32:34 DEBUG Executing event instance_id=a72943ce-f8e6-42ad-a956-01fea93a3314 event_id=4a8a701d-f39f-48dc-9790-d8dd622f6e40 seq_id=0 event_type=TimerFired schedule_event_id=0 is_replaying=false
2022/12/02 15:32:34 DEBUG Finished workflow task task_id=947f025b-863f-49eb-8f69-06fd018195c0 instance_id=instanceID executed=5 last_sequence_id=5 completed=true
--- PASS: Test_Executor (0.00s)
    --- PASS: Test_Executor/Reorder_events_to_protect_against_nil_deref_error (0.00s)
PASS
ok      github.com/cschleiden/go-workflows/internal/workflow    0.448s
```
With the fix, the executor is executing these events in the following order (output truncated):
```
2022/12/02 15:32:34 DEBUG Executing event ... event_type=WorkflowTaskStarted schedule_event_id=0 is_replaying=false
2022/12/02 15:32:34 DEBUG Executing event ... event_type=WorkflowExecutionStarted schedule_event_id=0 is_replaying=false
2022/12/02 15:32:34 DEBUG Executing event  ... event_type=SignalReceived schedule_event_id=0 is_replaying=false
2022/12/02 15:32:34 DEBUG Executing event ... event_type=TimerFired schedule_event_id=0 is_replaying=false
2022/12/02 15:32:34 DEBUG Finished workflow task task_id=947f025b-863f-49eb-8f69-06fd018195c0 instance_id=instanceID executed=5 last_sequence_id=5 completed=true
```
1. `WorkflowTaskStarted` 😄 
2. `WorkflowExecutionStarted` 😄 
3. `SignalReceived` 😄 
4. `TimerFired` 😃 🎊 
5. (not shown in output because the executor currently [ignores](https://github.com/cschleiden/go-workflows/blob/c7407721e676674611c5b5c1a451dd4fae805a8b/internal/workflow/executor.go#L271-L271) this event) `WorkflowExecutionFinished` ✅ 