### PR TITLE
Fixed return type of NewSqliteBackend

### DIFF
--- a/backend/sqlite/sqlite.go
+++ b/backend/sqlite/sqlite.go
@@ -35,7 +35,7 @@ func NewInMemoryBackend(opts ...backend.BackendOption) *sqliteBackend {
 	return b
 }
 
-func NewSqliteBackend(path string, opts ...backend.BackendOption) backend.Backend {
+func NewSqliteBackend(path string, opts ...backend.BackendOption) *sqliteBackend {
 	return newSqliteBackend(fmt.Sprintf("file:%v", path), opts...)
 }
 


### PR DESCRIPTION
There appears to be a typo in the return type of `NewSqliteBackend` which produces this compiler error when trying to use it

```
orch/orch.go:123:12: cannot use b (variable of type backend.Backend) as type diag.Backend in struct literal:
        backend.Backend does not implement diag.Backend (missing GetWorkflowInstance method)
```