### PR TITLE
allow conflicting names in different packages

### DIFF
--- a/backend/test/e2e.go
+++ b/backend/test/e2e.go
@@ -71,7 +71,7 @@ func EndToEndBackendTest(t *testing.T, setup func() TestBackend, teardown func(b
 				output, err := runWorkflowWithResult[string](t, ctx, c, wf, "hello")
 
 				require.Zero(t, output)
-				require.ErrorContains(t, err, "workflow 1 not found")
+				require.ErrorContains(t, err, "not found")
 			},
 		},
 		{

--- a/internal/fn/fn.go
+++ b/internal/fn/fn.go
@@ -8,10 +8,5 @@ import (
 
 func Name(i interface{}) string {
 	// Adapted from https://stackoverflow.com/a/7053871
-	fnName := runtime.FuncForPC(reflect.ValueOf(i).Pointer()).Name()
-
-	s := strings.Split(fnName, ".")
-	fnName = s[len(s)-1]
-
-	return strings.TrimSuffix(fnName, "-fm")
+	return strings.TrimSuffix(runtime.FuncForPC(reflect.ValueOf(i).Pointer()).Name(), "-fm")
 }

--- a/internal/fn/fn_test.go
+++ b/internal/fn/fn_test.go
@@ -32,17 +32,17 @@ func Test_GetFunctionName(t *testing.T) {
 		{
 			name: "function",
 			i:    bar,
-			want: "bar",
+			want: "github.com/cschleiden/go-workflows/internal/fn.bar",
 		},
 		{
 			name: "struct method",
 			i:    f.bar,
-			want: "bar",
+			want: "github.com/cschleiden/go-workflows/internal/fn.(*foo).bar",
 		},
 		{
 			name: "exported struct method",
 			i:    f.DoSomething,
-			want: "DoSomething",
+			want: "github.com/cschleiden/go-workflows/internal/fn.(*foo).DoSomething",
 		},
 	}
 	for _, tt := range tests {

--- a/internal/workflow/executor_test.go
+++ b/internal/workflow/executor_test.go
@@ -117,7 +117,7 @@ func Test_Executor(t *testing.T) {
 				inputs, _ := converter.DefaultConverter.To(42)
 				require.IsType(t, &command.ScheduleActivityCommand{}, e.workflowState.Commands()[0])
 				require.Equal(t, command.CommandState_Committed, e.workflowState.Commands()[0].State())
-				require.Equal(t, "activity1", e.workflowState.Commands()[0].(*command.ScheduleActivityCommand).Name)
+				require.Equal(t, fn.Name(activity1), e.workflowState.Commands()[0].(*command.ScheduleActivityCommand).Name)
 				require.Equal(t, []payload.Payload{inputs}, e.workflowState.Commands()[0].(*command.ScheduleActivityCommand).Inputs)
 			},
 		},
@@ -162,7 +162,7 @@ func Test_Executor(t *testing.T) {
 						time.Now(),
 						history.EventType_ActivityScheduled,
 						&history.ActivityScheduledAttributes{
-							Name:   "activity1",
+							Name:   fn.Name(activity1),
 							Inputs: []payload.Payload{inputs},
 						},
 						history.ScheduleEventID(1),
@@ -222,7 +222,7 @@ func Test_Executor(t *testing.T) {
 							time.Now(),
 							history.EventType_ActivityScheduled,
 							&history.ActivityScheduledAttributes{
-								Name:   "activity1",
+								Name:   fn.Name(activity1),
 								Inputs: []payload.Payload{inputs},
 							},
 							history.ScheduleEventID(1),

--- a/internal/workflow/registry.go
+++ b/internal/workflow/registry.go
@@ -118,7 +118,7 @@ func (r *Registry) registerActivitiesFromStruct(a interface{}) error {
 			return err
 		}
 
-		name := mt.Name
+		name := fn.Name(mt.Func.Interface())
 		r.activityMap[name] = mv.Interface()
 	}
 


### PR DESCRIPTION
Currently go-workflows only keeps the relative name of the function.
This breaks activity structs with the same method names.
What if workflows and activities used fully qualified names?

