### PR TITLE
Do not run tester timers while activities are running

### DIFF
--- a/tester/tester.go
+++ b/tester/tester.go
@@ -328,11 +328,6 @@ func (wt *workflowTester[TResult]) Execute(args ...interface{}) {
 
 				wt.scheduleTimer(tw.instance, timerEvent)
 			}
-
-			// Schedule activities
-			for _, event := range result.ActivityEvents {
-				wt.scheduleActivity(tw.instance, event)
-			}
 		}
 
 		for !wt.workflowFinished && !gotNewEvents {

--- a/tester/tester_timers_test.go
+++ b/tester/tester_timers_test.go
@@ -1,6 +1,7 @@
 package tester
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -132,4 +133,32 @@ func workflowTimerRespondingWithoutNewEvents(ctx workflow.Context) error {
 	)
 
 	return nil
+}
+
+func Test_TimerDuringActivities(t *testing.T) {
+	activityFinished := false
+
+	act := func(ctx context.Context) error {
+		time.Sleep(100 * time.Millisecond)
+		activityFinished = true
+		return nil
+	}
+
+	wf := func(ctx workflow.Context) error {
+		_, err := workflow.ExecuteActivity[any](ctx, workflow.DefaultActivityOptions, act).Get(ctx)
+		return err
+	}
+
+	tester := NewWorkflowTester[timerResult](wf)
+	tester.Registry().RegisterActivity(act)
+
+	tester.ScheduleCallback(time.Duration(50*time.Millisecond), func() {
+		require.True(t, activityFinished, "Activity should have finished before timer is fired")
+	})
+
+	tester.Execute()
+
+	require.True(t, tester.WorkflowFinished())
+	_, wrErr := tester.WorkflowResult()
+	require.Empty(t, wrErr)
 }


### PR DESCRIPTION
This change modifies the tester to not run scheduled callbacks/timers while activities are running. 

This does not yet address cases where there is a legitimate race between an activity and a timer, this will be done in a followup PR. 
