### PR TITLE
Make error message clearer

### DIFF
--- a/tester/tester.go
+++ b/tester/tester.go
@@ -219,7 +219,7 @@ func NewWorkflowTester[TResult any](wf interface{}, opts ...WorkflowTesterOption
 
 	// Always register the workflow under test
 	if err := wt.registry.RegisterWorkflow(wf); err != nil {
-		panic(fmt.Sprintf("could not workflow under test: %v", err))
+		panic(fmt.Sprintf("could not register workflow under test: %v", err))
 	}
 
 	return wt


### PR DESCRIPTION
Makes the error message when registering the workflow under test in `tester.go` a tad bit clearer