### PR TITLE
Support invalid state transition for finished commands during workflow cancellation 

### DIFF
--- a/internal/command/cancelablecommand.go
+++ b/internal/command/cancelablecommand.go
@@ -38,6 +38,10 @@ func (c *cancelableCommand) Done() {
 	switch c.state {
 	case CommandState_Committed, CommandState_Canceled:
 		c.state = CommandState_Done
+		if c.whenDone != nil {
+			c.whenDone()
+		}
+
 	default:
 		c.invalidStateTransition(CommandState_Done)
 	}

--- a/internal/command/sideeffect.go
+++ b/internal/command/sideeffect.go
@@ -65,6 +65,9 @@ func (c *SideEffectCommand) Done() {
 	switch c.state {
 	case CommandState_Pending, CommandState_Committed:
 		c.state = CommandState_Done
+		if c.whenDone != nil {
+			c.whenDone()
+		}
 
 	default:
 		c.invalidStateTransition(CommandState_Done)

--- a/workflow/timer_test.go
+++ b/workflow/timer_test.go
@@ -1,0 +1,50 @@
+package workflow
+
+import (
+	"testing"
+	"time"
+
+	"github.com/benbjohnson/clock"
+	"github.com/cschleiden/go-workflows/internal/converter"
+	"github.com/cschleiden/go-workflows/internal/core"
+	"github.com/cschleiden/go-workflows/internal/logger"
+	"github.com/cschleiden/go-workflows/internal/sync"
+	"github.com/cschleiden/go-workflows/internal/workflowstate"
+	"github.com/cschleiden/go-workflows/internal/workflowtracer"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func Test_Timer_Cancellation(t *testing.T) {
+	state := workflowstate.NewWorkflowState(core.NewWorkflowInstance("a", ""), logger.NewDefaultLogger(), clock.New())
+
+	ctx, cancel := sync.WithCancel(sync.Background())
+	ctx = converter.WithConverter(ctx, converter.DefaultConverter)
+	ctx = workflowstate.WithWorkflowState(ctx, state)
+	ctx = workflowtracer.WithWorkflowTracer(ctx, workflowtracer.New(trace.NewNoopTracerProvider().Tracer("test")))
+
+	c := sync.NewCoroutine(ctx, func(ctx sync.Context) error {
+		f := ScheduleTimer(ctx, time.Second*1)
+		f.Get(ctx)
+
+		// Block workflow
+		sync.NewFuture[int]().Get(ctx)
+
+		return nil
+	})
+	c.Execute()
+	require.False(t, c.Finished())
+
+	// Fire timer
+	cmd := state.CommandByScheduleEventID(1)
+	cmd.Commit()
+	cmd.Done()
+	fs, ok := state.FutureByScheduleEventID(1)
+	require.True(t, ok)
+	fs(nil, nil)
+
+	c.Execute()
+	require.False(t, c.Finished())
+
+	cancel()
+}


### PR DESCRIPTION
Changes:
- `func`s in Go cannot be compared, so change `Channel` to accept `struct`s for cancellation callbacks
- Add option to remove cancellation callbacks
- When a Timer or SubWorkflow command is finished, remove the cancellation callback to prevent invalid state transitions.

Fixes: https://github.com/cschleiden/go-workflows/issues/160 