### PR TITLE
Support removing workflow instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,19 @@ wf, err := c.CreateWorkflowInstance(ctx, client.WorkflowInstanceOptions{
 	InstanceID: uuid.NewString(),
 }, Workflow1, "input-for-workflow")
 if err != nil {
+	// ...
+}
+```
+
+### Removing workflow instances
+
+`RemoveWorkflowInstance` on a client instance will remove that workflow instance including all history data from the backend. A workflow instance needs to be in the finished state before calling this, otherwise an error will be returned.
+
+```go
+err = c.RemoveWorkflowInstance(ctx, workflowInstance)
+if err != nil {
+	// ...
+}
 ```
 
 ### Canceling workflows

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -16,6 +16,7 @@ import (
 
 var ErrInstanceNotFound = errors.New("workflow instance not found")
 var ErrInstanceAlreadyExists = errors.New("workflow instance already exists")
+var ErrInstanceNotFinished = errors.New("workflow instance is not finished")
 
 const TracerName = "go-workflow"
 
@@ -26,6 +27,9 @@ type Backend interface {
 
 	// CancelWorkflowInstance cancels a running workflow instance
 	CancelWorkflowInstance(ctx context.Context, instance *workflow.Instance, cancelEvent *history.Event) error
+
+	// RemoveWorkflowInstance removes a workflow instance
+	RemoveWorkflowInstance(ctx context.Context, instance *workflow.Instance) error
 
 	// GetWorkflowInstanceState returns the state of the given workflow instance
 	GetWorkflowInstanceState(ctx context.Context, instance *workflow.Instance) (core.WorkflowInstanceState, error)

--- a/backend/mock_Backend.go
+++ b/backend/mock_Backend.go
@@ -260,6 +260,20 @@ func (_m *MockBackend) Metrics() metrics.Client {
 	return r0
 }
 
+// RemoveWorkflowInstance provides a mock function with given fields: ctx, instance
+func (_m *MockBackend) RemoveWorkflowInstance(ctx context.Context, instance *core.WorkflowInstance) error {
+	ret := _m.Called(ctx, instance)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, *core.WorkflowInstance) error); ok {
+		r0 = rf(ctx, instance)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // SignalWorkflow provides a mock function with given fields: ctx, instanceID, event
 func (_m *MockBackend) SignalWorkflow(ctx context.Context, instanceID string, event *history.Event) error {
 	ret := _m.Called(ctx, instanceID, event)

--- a/backend/redis/delete.go
+++ b/backend/redis/delete.go
@@ -1,0 +1,34 @@
+package redis
+
+import (
+	"context"
+	"fmt"
+
+	redis "github.com/redis/go-redis/v9"
+)
+
+// KEYS[1] - instance key
+// KEYS[2] - pending events key
+// KEYS[3] - history key
+// KEYS[4] - instances-by-creation key
+// ARGV[1] - instance ID
+var deleteCmd = redis.NewScript(
+	`redis.call("DEL", KEYS[1], KEYS[2], KEYS[3])
+	return redis.call("ZREM", KEYS[4], ARGV[1])`)
+
+// deleteInstance deletes an instance from Redis. It does not attempt to remove any future events or pending
+// workflow tasks. It's assumed that the instance is in the finished state.
+//
+// Note: might want to revisit this in the future if we want to support removing hung instances.
+func deleteInstance(ctx context.Context, rdb redis.UniversalClient, instanceID string) error {
+	if err := deleteCmd.Run(ctx, rdb, []string{
+		instanceKey(instanceID),
+		pendingEventsKey(instanceID),
+		historyKey(instanceID),
+		instancesByCreation(),
+	}, instanceID).Err(); err != nil {
+		return fmt.Errorf("failed to delete instance: %w", err)
+	}
+
+	return nil
+}

--- a/backend/redis/instance.go
+++ b/backend/redis/instance.go
@@ -109,6 +109,20 @@ func (rb *redisBackend) CancelWorkflowInstance(ctx context.Context, instance *co
 	return nil
 }
 
+func (rb *redisBackend) RemoveWorkflowInstance(ctx context.Context, instance *core.WorkflowInstance) error {
+	i, err := readInstance(ctx, rb.rdb, instance.InstanceID)
+	if err != nil {
+		return err
+	}
+
+	// Check state
+	if i.State != core.WorkflowInstanceStateFinished {
+		return backend.ErrInstanceNotFinished
+	}
+
+	return deleteInstance(ctx, rb.rdb, instance.InstanceID)
+}
+
 type instanceState struct {
 	Instance *core.WorkflowInstance     `json:"instance,omitempty"`
 	State    core.WorkflowInstanceState `json:"state,omitempty"`

--- a/backend/redis/keys.go
+++ b/backend/redis/keys.go
@@ -8,6 +8,8 @@ func instanceKey(instanceID string) string {
 	return fmt.Sprintf("instance:%v", instanceID)
 }
 
+// instancesByCreation returns the key for the ZSET that contains all instances sorted by creation date. The score is the
+// creation time. Used for listing all workflow instances in the diagnostics UI.
 func instancesByCreation() string {
 	return "instances-by-creation"
 }

--- a/backend/redis/redis.go
+++ b/backend/redis/redis.go
@@ -69,7 +69,7 @@ func NewRedisBackend(client redis.UniversalClient, opts ...RedisBackendOption) (
 		activityQueue: activityQueue,
 	}
 
-	// Preload scripts here. Usually redis-go attempts to execute them first, and the if redis doesn't know
+	// Preload scripts here. Usually redis-go attempts to execute them first, and if redis doesn't know
 	// them, loads them. This doesn't work when using (transactional) pipelines, so eagerly load them on startup.
 	ctx := context.Background()
 	cmds := map[string]*redis.StringCmd{
@@ -79,6 +79,7 @@ func NewRedisBackend(client redis.UniversalClient, opts ...RedisBackendOption) (
 		"removeFutureEventCmd":   removeFutureEventCmd.Load(ctx, rb.rdb),
 		"removePendingEventsCmd": removePendingEventsCmd.Load(ctx, rb.rdb),
 		"requeueInstanceCmd":     requeueInstanceCmd.Load(ctx, rb.rdb),
+		"deleteInstanceCmd":      deleteCmd.Load(ctx, rb.rdb),
 	}
 	for name, cmd := range cmds {
 		// fmt.Println(name, cmd.Val())

--- a/client/client.go
+++ b/client/client.go
@@ -36,6 +36,8 @@ type Client interface {
 
 	CancelWorkflowInstance(ctx context.Context, instance *workflow.Instance) error
 
+	RemoveWorkflowInstance(ctx context.Context, instance *workflow.Instance) error
+
 	WaitForWorkflowInstance(ctx context.Context, instance *workflow.Instance, timeout time.Duration) error
 
 	SignalWorkflow(ctx context.Context, instanceID string, name string, arg interface{}) error
@@ -202,4 +204,8 @@ func GetWorkflowResult[T any](ctx context.Context, c Client, instance *workflow.
 	}
 
 	return *new(T), errors.New("workflow finished, but could not find result event")
+}
+
+func (c *client) RemoveWorkflowInstance(ctx context.Context, instance *core.WorkflowInstance) error {
+	return c.backend.RemoveWorkflowInstance(ctx, instance)
 }


### PR DESCRIPTION
Contributes to #28 

Not yet an automated or time based cleanup, but a way to explicitly remove finished workflow instances.