### PR TITLE
Automatic expiration of finished workflow instances 

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,8 @@ b := mysql.NewMysqlBackend("localhost", 3306, "root", "SqlPassw0rd", "simple")
 #### Redis
 
 ```go
-b, err := redis.NewRedisBackend("localhost:6379", "user", "RedisPassw0rd", 0)
+redisClient := ...
+b, err := redis.NewRedisBackend(redisClient)
 if err != nil {
 	panic(err)
 }
@@ -249,6 +250,15 @@ err = c.RemoveWorkflowInstance(ctx, workflowInstance)
 if err != nil {
 	// ...
 }
+```
+
+#### Automatically expiring finished workflow instances
+
+For now this is only supported for the Redis backend. When an `AutoExpiration` is passed to the backend, finished workflow instances will be automatically removed after the specified duration. This works by setting a TTL on the Redis keys for finished workflow instances. If `AutoExpiration` is set to `0` (the default), no TTL will be set.
+
+```go
+b, err := redis.NewRedisBackend(redisClient, redis.WithAutoExpiration(time.Hour * 48))
+// ...
 ```
 
 ### Canceling workflows

--- a/backend/redis/expire.go
+++ b/backend/redis/expire.go
@@ -1,0 +1,63 @@
+package redis
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	redis "github.com/redis/go-redis/v9"
+)
+
+// We can't have events for redis..we do not want to do it in-process..
+
+// Set the given expiration time on all keys passed in
+// KEYS[1] - instances-by-creation key
+// KEYS[2] - instances-expiring key
+// KEYS[3] - instance key
+// KEYS[4] - pending events key
+// KEYS[5] - history key
+// ARGV[1] - current timestamp
+// ARGV[2] - expiration time in seconds
+// ARGV[3] - expiration timestamp in unix milliseconds
+// ARGV[4] - instance ID
+var expireCmd = redis.NewScript(
+	`-- Find instances which have already expired and remove from the index set
+	local expiredInstances = redis.call("ZRANGE", KEYS[2], "-inf", ARGV[1], "BYSCORE")
+	for i = 1, #expiredInstances do
+		local instanceID = expiredInstances[i]
+		redis.call("ZREM", KEYS[1], instanceID) -- index set
+		redis.call("ZREM", KEYS[2], instanceID) -- expiration set
+	end
+
+	-- Add expiration time for future cleanup
+	redis.call("ZADD", KEYS[2], ARGV[3], ARGV[4])
+
+	-- Set expiration on all keys
+	for i = 3, #KEYS do
+		redis.call("EXPIRE", KEYS[i], ARGV[2])
+	end
+
+	return 0
+	`,
+)
+
+func setWorkflowInstanceExpiration(ctx context.Context, rdb redis.UniversalClient, instanceID string, expiration time.Duration) error {
+	now := time.Now().UnixMilli()
+	nowStr := strconv.FormatInt(now, 10)
+
+	exp := time.Now().Add(expiration).UnixMilli()
+	expStr := strconv.FormatInt(exp, 10)
+
+	return expireCmd.Run(ctx, rdb, []string{
+		instancesByCreation(),
+		instancesExpiring(),
+		instanceKey(instanceID),
+		pendingEventsKey(instanceID),
+		historyKey(instanceID),
+	},
+		nowStr,
+		expiration.Seconds(),
+		expStr,
+		instanceID,
+	).Err()
+}

--- a/backend/redis/expire_test.go
+++ b/backend/redis/expire_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/cschleiden/go-workflows/backend"
 	"github.com/cschleiden/go-workflows/client"
+	"github.com/cschleiden/go-workflows/internal/core"
 	"github.com/cschleiden/go-workflows/worker"
 	"github.com/cschleiden/go-workflows/workflow"
 	"github.com/google/uuid"
@@ -35,6 +36,8 @@ func Test_AutoExpiration(t *testing.T) {
 		return nil
 	}
 
+	w.RegisterWorkflow(wf)
+
 	wfi, err := c.CreateWorkflowInstance(ctx, client.WorkflowInstanceOptions{
 		InstanceID: uuid.NewString(),
 	}, wf)
@@ -45,6 +48,67 @@ func Test_AutoExpiration(t *testing.T) {
 	// Wait for redis to expire the keys
 	time.Sleep(autoExpirationTime)
 
+	_, err = b.GetWorkflowInstanceState(ctx, wfi)
+	require.ErrorIs(t, err, backend.ErrInstanceNotFound)
+
+	cancel()
+	require.NoError(t, w.WaitForCompletion())
+}
+
+func Test_AutoExpiration_SubWorkflow(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	autoExpirationTime := time.Second * 1
+
+	redisClient := getClient()
+	setup := getCreateBackend(redisClient, WithAutoExpiration(autoExpirationTime))
+	b := setup()
+
+	c := client.New(b)
+	w := worker.New(b, &worker.DefaultWorkerOptions)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	require.NoError(t, w.Start(ctx))
+
+	swf := func(ctx workflow.Context) (int, error) {
+		return 42, nil
+	}
+
+	swfInstanceID := uuid.NewString()
+
+	wf := func(ctx workflow.Context) (int, error) {
+		r, err := workflow.CreateSubWorkflowInstance[int](ctx, workflow.SubWorkflowOptions{
+			InstanceID: swfInstanceID,
+		}, swf).Get(ctx)
+
+		workflow.ScheduleTimer(ctx, time.Second*2).Get(ctx)
+
+		return r, err
+	}
+
+	w.RegisterWorkflow(wf)
+	w.RegisterWorkflow(swf)
+
+	wfi, err := c.CreateWorkflowInstance(ctx, client.WorkflowInstanceOptions{
+		InstanceID: uuid.NewString(),
+	}, wf)
+	require.NoError(t, err)
+
+	r, err := client.GetWorkflowResult[int](ctx, c, wfi, time.Second*10)
+	require.NoError(t, err)
+	require.Equal(t, 42, r)
+
+	// Subworkflow should be expired by now
+	_, err = b.GetWorkflowInstanceState(ctx, core.NewWorkflowInstance(swfInstanceID))
+	require.ErrorIs(t, err, backend.ErrInstanceNotFound)
+
+	// Wait for redis to expire the keys
+	time.Sleep(autoExpirationTime)
+
+	// Main workflow should now be expired
 	_, err = b.GetWorkflowInstanceState(ctx, wfi)
 	require.ErrorIs(t, err, backend.ErrInstanceNotFound)
 

--- a/backend/redis/expire_test.go
+++ b/backend/redis/expire_test.go
@@ -1,0 +1,53 @@
+package redis
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cschleiden/go-workflows/backend"
+	"github.com/cschleiden/go-workflows/client"
+	"github.com/cschleiden/go-workflows/worker"
+	"github.com/cschleiden/go-workflows/workflow"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_AutoExpiration(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	autoExpirationTime := time.Second * 1
+
+	redisClient := getClient()
+	setup := getCreateBackend(redisClient, WithAutoExpiration(autoExpirationTime))
+	b := setup()
+
+	c := client.New(b)
+	w := worker.New(b, &worker.DefaultWorkerOptions)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	require.NoError(t, w.Start(ctx))
+
+	wf := func(ctx workflow.Context) error {
+		return nil
+	}
+
+	wfi, err := c.CreateWorkflowInstance(ctx, client.WorkflowInstanceOptions{
+		InstanceID: uuid.NewString(),
+	}, wf)
+	require.NoError(t, err)
+
+	require.NoError(t, c.WaitForWorkflowInstance(ctx, wfi, time.Second*10))
+
+	// Wait for redis to expire the keys
+	time.Sleep(autoExpirationTime)
+
+	_, err = b.GetWorkflowInstanceState(ctx, wfi)
+	require.ErrorIs(t, err, backend.ErrInstanceNotFound)
+
+	cancel()
+	require.NoError(t, w.WaitForCompletion())
+}

--- a/backend/redis/keys.go
+++ b/backend/redis/keys.go
@@ -14,6 +14,10 @@ func instancesByCreation() string {
 	return "instances-by-creation"
 }
 
+func instancesExpiring() string {
+	return "instances-expiring"
+}
+
 func pendingEventsKey(instanceID string) string {
 	return fmt.Sprintf("pending-events:%v", instanceID)
 }

--- a/backend/redis/options.go
+++ b/backend/redis/options.go
@@ -1,0 +1,39 @@
+package redis
+
+import (
+	"time"
+
+	"github.com/cschleiden/go-workflows/backend"
+)
+
+type RedisOptions struct {
+	backend.Options
+
+	BlockTimeout time.Duration
+
+	AutoExpiration time.Duration
+}
+
+type RedisBackendOption func(*RedisOptions)
+
+func WithBlockTimeout(timeout time.Duration) RedisBackendOption {
+	return func(o *RedisOptions) {
+		o.BlockTimeout = timeout
+	}
+}
+
+func WithBackendOptions(opts ...backend.BackendOption) RedisBackendOption {
+	return func(o *RedisOptions) {
+		for _, opt := range opts {
+			opt(&o.Options)
+		}
+	}
+}
+
+// WithAutoExpiration sets the duration after which finished runs will expire from the data store.
+// If set to 0 (default), runs will never expire and need to be manually removed.
+func WithAutoExpiration(expireFinishedRunsAfter time.Duration) RedisBackendOption {
+	return func(o *RedisOptions) {
+		o.AutoExpiration = expireFinishedRunsAfter
+	}
+}

--- a/backend/redis/redis.go
+++ b/backend/redis/redis.go
@@ -58,6 +58,7 @@ func NewRedisBackend(client redis.UniversalClient, opts ...RedisBackendOption) (
 		"removePendingEventsCmd": removePendingEventsCmd.Load(ctx, rb.rdb),
 		"requeueInstanceCmd":     requeueInstanceCmd.Load(ctx, rb.rdb),
 		"deleteInstanceCmd":      deleteCmd.Load(ctx, rb.rdb),
+		"expireInstanceCmd":      expireCmd.Load(ctx, rb.rdb),
 	}
 	for name, cmd := range cmds {
 		// fmt.Println(name, cmd.Val())

--- a/backend/redis/redis.go
+++ b/backend/redis/redis.go
@@ -16,28 +16,6 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-type RedisOptions struct {
-	backend.Options
-
-	BlockTimeout time.Duration
-}
-
-type RedisBackendOption func(*RedisOptions)
-
-func WithBlockTimeout(timeout time.Duration) RedisBackendOption {
-	return func(o *RedisOptions) {
-		o.BlockTimeout = timeout
-	}
-}
-
-func WithBackendOptions(opts ...backend.BackendOption) RedisBackendOption {
-	return func(o *RedisOptions) {
-		for _, opt := range opts {
-			opt(&o.Options)
-		}
-	}
-}
-
 var _ backend.Backend = (*redisBackend)(nil)
 
 func NewRedisBackend(client redis.UniversalClient, opts ...RedisBackendOption) (*redisBackend, error) {


### PR DESCRIPTION
Allows setting an automatic expiration for finished workflows in the Redis backend. See the `README.md` for how to use and the integration test included here. 

Closes: #45