### PR TITLE
Make analyzer work for multiple files

### DIFF
--- a/analyzer/analyzer_test.go
+++ b/analyzer/analyzer_test.go
@@ -3,9 +3,22 @@ package analyzer
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"golang.org/x/tools/go/analysis/analysistest"
 )
 
 func TestAll(t *testing.T) {
-	analysistest.Run(t, analysistest.TestData(), Analyzer, "p", "q")
+	a := New()
+	a.Flags.Set("checkprivatereturnvalues", "true")
+	analysistest.Run(t, analysistest.TestData(), a, "p", "q")
+}
+
+func TestComplex(t *testing.T) {
+	a := New()
+	a.Flags.Set("checkprivatereturnvalues", "true")
+	result := analysistest.Run(t, analysistest.TestData(), a, "q")
+	for _, r := range result {
+		require.NoError(t, r.Err)
+		require.Equal(t, 1, len(r.Diagnostics))
+	}
 }

--- a/analyzer/plugin/plugin.go
+++ b/analyzer/plugin/plugin.go
@@ -13,7 +13,7 @@ type analyzerPlugin struct{}
 
 func (*analyzerPlugin) GetAnalyzers() []*analysis.Analyzer {
 	return []*analysis.Analyzer{
-		analyzer.Analyzer,
+		analyzer.New(),
 	}
 }
 

--- a/analyzer/testdata/src/p/p.go
+++ b/analyzer/testdata/src/p/p.go
@@ -1,7 +1,6 @@
 // nolint
 package p
 
-// Work around module issues. The analyzer just looks for `workflow.Context` currently
 import (
 	"context"
 	"fmt"

--- a/analyzer/testdata/src/q/q1.go
+++ b/analyzer/testdata/src/q/q1.go
@@ -1,0 +1,9 @@
+// nolint
+package q
+
+type MyKey int
+
+const (
+	MyKey1 MyKey = iota
+	MyKey2
+)

--- a/analyzer/testdata/src/q/q2.go
+++ b/analyzer/testdata/src/q/q2.go
@@ -1,7 +1,6 @@
 // nolint
 package q
 
-// Work around module issues. The analyzer just looks for `workflow.Context` currently
 import (
 	wf "github.com/cschleiden/go-workflows/workflow"
 )


### PR DESCRIPTION
- Handle multiple files in the analyzer
- Pre-filter AST nodes for better performance
- By default does not check private (not exported) workflows in a file. Can be overridden via the `checkprivatereturnvalues` flag. Unfortunately golangci-lint doesn't yet support passing configuration to custom linters so you'll have to update/copy  `plugin/plugin.go` for now.