### PR TITLE
Fix: flatten logging fields regression

### DIFF
--- a/internal/workflow/executor.go
+++ b/internal/workflow/executor.go
@@ -296,7 +296,7 @@ func (e *executor) executeEvent(event *history.Event) error {
 		fields = append(fields, attributesFields...)
 	}
 
-	e.logger.Debug("Executing event", fields)
+	e.logger.Debug("Executing event", fields...)
 
 	var err error
 


### PR DESCRIPTION
https://github.com/cschleiden/go-workflows/pull/220 

In that PR we are passing  a single argument to the function, which is a slice. In this case, the function receives a slice of `interface{} ([]interface{})` where the only element is another slice of `interface{}`.

To retain existing behavior, using `...`