### PR TITLE
do not silently ignore errors in ActivityWorker.poll

### DIFF
--- a/internal/worker/activity.go
+++ b/internal/worker/activity.go
@@ -201,6 +201,8 @@ func (aw *ActivityWorker) poll(ctx context.Context, timeout time.Duration) (*bac
 		if errors.Is(err, context.DeadlineExceeded) {
 			return nil, nil
 		}
+
+		return nil, err
 	}
 
 	return task, nil


### PR DESCRIPTION
Something I noticed while running this with our workloads, we probably don't want to silently ignore errors that are not `DeadlineExceeded`.