### PR TITLE
Sqlite: store payloads/attributes in separate table

### DIFF
--- a/backend/sqlite/activities.go
+++ b/backend/sqlite/activities.go
@@ -3,30 +3,29 @@ package sqlite
 import (
 	"context"
 	"database/sql"
+	"fmt"
 
 	"github.com/cschleiden/go-workflows/backend/history"
 	"github.com/cschleiden/go-workflows/core"
 )
 
 func scheduleActivity(ctx context.Context, tx *sql.Tx, instance *core.WorkflowInstance, event *history.Event) error {
-	attributes, err := history.SerializeAttributes(event.Attributes)
-	if err != nil {
-		return err
-	}
+	// Attributes are already persisted via the history, we do not need to add them again.
 
-	_, err = tx.ExecContext(
+	if _, err := tx.ExecContext(
 		ctx,
 		`INSERT INTO activities
-			(id, instance_id, execution_id, event_type, timestamp, schedule_event_id, attributes, visible_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+			(id, instance_id, execution_id, event_type, timestamp, schedule_event_id, visible_at) VALUES (?, ?, ?, ?, ?, ?, ?)`,
 		event.ID,
 		instance.InstanceID,
 		instance.ExecutionID,
 		event.Type,
 		event.Timestamp,
 		event.ScheduleEventID,
-		attributes,
 		event.VisibleAt,
-	)
+	); err != nil {
+		return fmt.Errorf("inserting events: %w", err)
+	}
 
-	return err
+	return nil
 }

--- a/backend/sqlite/db/migrations/000002_add_attributes_table.down.sql
+++ b/backend/sqlite/db/migrations/000002_add_attributes_table.down.sql
@@ -1,0 +1,14 @@
+-- Move activity attributes to attributes table
+ALTER TABLE `activities` ADD COLUMN `attributes` BLOB NULL;
+UPDATE `activities` SET `attributes` = `attributes`.`data` FROM `attributes` WHERE `activities`.`id` = `attributes`.`id` AND `activities`.`instance_id` = `attributes`.`instance_id` AND `activities`.`execution_id` = `attributes`.`execution_id`;
+
+-- Move history attributes to attributes table
+ALTER TABLE `history` ADD COLUMN `attributes` BLOB NULL;
+UPDATE `history` SET `attributes` = `attributes`.`data` FROM `attributes` WHERE `history`.`id` = `attributes`.`id` AND `history`.`instance_id` = `attributes`.`instance_id` AND `history`.`execution_id` = `attributes`.`execution_id`;
+
+-- Move pending_events attributes to attributes table
+ALTER TABLE `pending_events` ADD COLUMN `attributes` BLOB NULL;
+UPDATE `pending_events` SET `attributes` = `attributes`.`data` FROM `attributes` WHERE `pending_events`.`id` = `attributes`.`id` AND `pending_events`.`instance_id` = `attributes`.`instance_id` AND `pending_events`.`execution_id` = `attributes`.`execution_id`;
+
+-- Drop attributes table
+DROP TABLE `attributes`;

--- a/backend/sqlite/db/migrations/000002_add_attributes_table.up.sql
+++ b/backend/sqlite/db/migrations/000002_add_attributes_table.up.sql
@@ -1,0 +1,19 @@
+CREATE TABLE IF NOT EXISTS `attributes` (
+  `id` TEXT NOT NULL,
+  `instance_id` TEXT NOT NULL,
+  `execution_id` TEXT NOT NULL,
+  `data` BLOB NOT NULL,
+  PRIMARY KEY(`id`, `instance_id`)
+);
+
+-- Move activity attributes to payloads table
+INSERT OR IGNORE INTO `attributes` (`id`, `instance_id`, `execution_id`, `data`) SELECT `id`, `instance_id`, `execution_id`, `attributes` FROM `activities`;
+ALTER TABLE `activities` DROP COLUMN `attributes`;
+
+-- Move history attributes to payloads table
+INSERT OR IGNORE INTO `attributes` (`id`, `instance_id`, `execution_id`, `data`) SELECT `id`, `instance_id`, `execution_id`, `attributes` FROM `history`;
+ALTER TABLE `history` DROP COLUMN `attributes`;
+
+-- Move pending_events attributes to payloads table
+INSERT OR IGNORE INTO `attributes` (`id`, `instance_id`, `execution_id`, `data`) SELECT `id`, `instance_id`, `execution_id`, `attributes` FROM `pending_events`;
+ALTER TABLE `pending_events` DROP COLUMN `attributes`;

--- a/backend/sqlite/sqlite.go
+++ b/backend/sqlite/sqlite.go
@@ -499,6 +499,7 @@ func (sb *sqliteBackend) CompleteWorkflowTask(
 			args = append(args, e.ID)
 		}
 
+		// Remove from pending
 		if _, err := tx.ExecContext(
 			ctx,
 			fmt.Sprintf(`DELETE FROM pending_events WHERE instance_id = ? AND execution_id = ? AND id IN (?%v)`, strings.Repeat(",?", len(executedEvents)-1)),
@@ -508,9 +509,8 @@ func (sb *sqliteBackend) CompleteWorkflowTask(
 		}
 	}
 
-	// Add events from last execution to history
-	if err := insertHistoryEvents(ctx, tx, instance, executedEvents); err != nil {
-		return fmt.Errorf("inserting new history events: %w", err)
+	if err := insertEvents(ctx, tx, "history", instance, executedEvents); err != nil {
+		return fmt.Errorf("inserting history events: %w", err)
 	}
 
 	// Schedule activities
@@ -608,7 +608,7 @@ func (sb *sqliteBackend) GetActivityTask(ctx context.Context) (*backend.Activity
 			SET locked_until = ?, worker = ?
 			WHERE rowid = (
 				SELECT rowid FROM activities WHERE locked_until IS NULL OR locked_until < ? LIMIT 1
-			) RETURNING id, instance_id, execution_id, event_type, timestamp, schedule_event_id, attributes, visible_at`,
+			) RETURNING id, instance_id, execution_id, event_type, timestamp, schedule_event_id, visible_at`,
 		now.Add(sb.options.ActivityLockTimeout),
 		sb.workerName,
 		now,
@@ -618,7 +618,6 @@ func (sb *sqliteBackend) GetActivityTask(ctx context.Context) (*backend.Activity
 	}
 
 	var instanceID, executionID string
-	var attributes []byte
 	event := &history.Event{}
 
 	if err := row.Scan(
@@ -628,7 +627,6 @@ func (sb *sqliteBackend) GetActivityTask(ctx context.Context) (*backend.Activity
 		&event.Type,
 		&event.Timestamp,
 		&event.ScheduleEventID,
-		&attributes,
 		&event.VisibleAt,
 	); err != nil {
 		if err == sql.ErrNoRows {
@@ -637,6 +635,13 @@ func (sb *sqliteBackend) GetActivityTask(ctx context.Context) (*backend.Activity
 		}
 
 		return nil, fmt.Errorf("scanning event: %w", err)
+	}
+
+	var attributes []byte
+	if err := tx.QueryRowContext(
+		ctx, "SELECT data FROM attributes WHERE instance_id = ? AND execution_id = ? AND id = ?", instanceID, executionID, event.ID,
+	).Scan(&attributes); err != nil {
+		return nil, fmt.Errorf("scanning attributes: %w", err)
 	}
 
 	a, err := history.DeserializeAttributes(event.Type, attributes)
@@ -676,7 +681,7 @@ func (sb *sqliteBackend) CompleteActivityTask(ctx context.Context, instance *wor
 	}
 	defer tx.Rollback()
 
-	// Remove activity
+	// Remove activity but keep the attributes, they are still needed for the history
 	if res, err := tx.ExecContext(
 		ctx,
 		`DELETE FROM activities WHERE instance_id = ? AND execution_id = ? AND id = ? AND worker = ?`,

--- a/backend/sqlite/sqlite.go
+++ b/backend/sqlite/sqlite.go
@@ -259,6 +259,10 @@ func (sb *sqliteBackend) RemoveWorkflowInstance(ctx context.Context, instance *c
 		return err
 	}
 
+	if _, err := tx.ExecContext(ctx, "DELETE FROM `attributes` WHERE instance_id = ? AND execution_id = ?", instanceID, executionID); err != nil {
+		return err
+	}
+
 	return tx.Commit()
 }
 


### PR DESCRIPTION
This change adds a new `attributes` table to the sqlite backend. Serialized attributes for events are stored in that table instead of inline. 

Contributes to: #39 