### PR TITLE
Delete and expire event payloads

### DIFF
--- a/backend/redis/delete.go
+++ b/backend/redis/delete.go
@@ -11,11 +11,13 @@ import (
 // KEYS[1] - instance key
 // KEYS[2] - pending events key
 // KEYS[3] - history key
-// KEYS[4] - instances-by-creation key
+// KEYS[4] - payload key
+// KEYS[5] - active-instance-execution key
+// KEYS[6] - instances-by-creation key
 // ARGV[1] - instance segment
 var deleteCmd = redis.NewScript(
-	`redis.call("DEL", KEYS[1], KEYS[2], KEYS[3])
-	return redis.call("ZREM", KEYS[4], ARGV[1])`)
+	`redis.call("DEL", KEYS[1], KEYS[2], KEYS[3], KEYS[4], KEYS[5])
+	return redis.call("ZREM", KEYS[6], ARGV[1])`)
 
 // deleteInstance deletes an instance from Redis. It does not attempt to remove any future events or pending
 // workflow tasks. It's assumed that the instance is in the finished state.
@@ -26,6 +28,8 @@ func deleteInstance(ctx context.Context, rdb redis.UniversalClient, instance *co
 		instanceKey(instance),
 		pendingEventsKey(instance),
 		historyKey(instance),
+		payloadKey(instance),
+		activeInstanceExecutionKey(instance.InstanceID),
 		instancesByCreation(),
 	}, instanceSegment(instance)).Err(); err != nil {
 		return fmt.Errorf("failed to delete instance: %w", err)

--- a/backend/redis/expire.go
+++ b/backend/redis/expire.go
@@ -17,6 +17,7 @@ import (
 // KEYS[3] - instance key
 // KEYS[4] - pending events key
 // KEYS[5] - history key
+// KEYS[6] - payload key
 // ARGV[1] - current timestamp
 // ARGV[2] - expiration time in seconds
 // ARGV[3] - expiration timestamp in unix milliseconds
@@ -55,6 +56,7 @@ func setWorkflowInstanceExpiration(ctx context.Context, rdb redis.UniversalClien
 		instanceKey(instance),
 		pendingEventsKey(instance),
 		historyKey(instance),
+		payloadKey(instance),
 	},
 		nowStr,
 		expiration.Seconds(),


### PR DESCRIPTION
Missed this when moving event payloads to a separate key. 