### PR TITLE
Track pending futures with a name

### DIFF
--- a/internal/workflowstate/workflowstate_test.go
+++ b/internal/workflowstate/workflowstate_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/benbjohnson/clock"
 	"github.com/cschleiden/go-workflows/backend/converter"
-	"github.com/cschleiden/go-workflows/backend/payload"
 	"github.com/cschleiden/go-workflows/core"
 	"github.com/cschleiden/go-workflows/internal/sync"
 	"github.com/google/uuid"
@@ -21,12 +20,7 @@ func Test_PendingFutures(t *testing.T) {
 	require.False(t, wfState.HasPendingFutures())
 
 	f := sync.NewFuture[int]()
-	wfState.TrackFuture(1, func(v payload.Payload, err error) error {
-		var r int
-		require.NoError(t, converter.DefaultConverter.From(v, &r))
-		f.Set(r, err)
-		return nil
-	})
+	wfState.TrackFuture(1, AsDecodingSettable[int](converter.DefaultConverter, "f", f))
 
 	require.True(t, wfState.HasPendingFutures())
 

--- a/workflow/activity.go
+++ b/workflow/activity.go
@@ -73,7 +73,7 @@ func executeActivity[TResult any](ctx Context, options ActivityOptions, attempt 
 
 	cmd := command.NewScheduleActivityCommand(scheduleEventID, name, inputs, metadata)
 	wfState.AddCommand(cmd)
-	wfState.TrackFuture(scheduleEventID, workflowstate.AsDecodingSettable(cv, f))
+	wfState.TrackFuture(scheduleEventID, workflowstate.AsDecodingSettable(cv, fmt.Sprintf("activity: %s", name), f))
 
 	ctx, span := workflowtracer.Tracer(ctx).Start(ctx,
 		fmt.Sprintf("ExecuteActivity: %s", name),

--- a/workflow/sideeffect.go
+++ b/workflow/sideeffect.go
@@ -28,7 +28,7 @@ func SideEffect[TResult any](ctx Context, f func(ctx Context) TResult) Future[TR
 	scheduleEventID := wfState.GetNextScheduleEventID()
 
 	cv := contextvalue.Converter(ctx)
-	wfState.TrackFuture(scheduleEventID, workflowstate.AsDecodingSettable(cv, future))
+	wfState.TrackFuture(scheduleEventID, workflowstate.AsDecodingSettable(cv, "sideeffect", future))
 
 	cmd := command.NewSideEffectCommand(scheduleEventID)
 	wfState.AddCommand(cmd)

--- a/workflow/subworkflow.go
+++ b/workflow/subworkflow.go
@@ -98,7 +98,7 @@ func createSubWorkflowInstance[TResult any](ctx Context, options SubWorkflowOpti
 	cmd := command.NewScheduleSubWorkflowCommand(scheduleEventID, wfState.Instance(), options.InstanceID, workflowName, inputs, metadata)
 
 	wfState.AddCommand(cmd)
-	wfState.TrackFuture(scheduleEventID, workflowstate.AsDecodingSettable(cv, f))
+	wfState.TrackFuture(scheduleEventID, workflowstate.AsDecodingSettable(cv, fmt.Sprintf("subworkflow:%s", workflowName), f))
 
 	// Check if the channel is cancelable
 	if c, cancelable := ctx.Done().(sync.CancelChannel); cancelable {

--- a/workflow/timer.go
+++ b/workflow/timer.go
@@ -1,6 +1,7 @@
 package workflow
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/cschleiden/go-workflows/internal/command"
@@ -30,7 +31,7 @@ func ScheduleTimer(ctx Context, delay time.Duration) Future[any] {
 
 	timerCmd := command.NewScheduleTimerCommand(scheduleEventID, at)
 	wfState.AddCommand(timerCmd)
-	wfState.TrackFuture(scheduleEventID, workflowstate.AsDecodingSettable(contextvalue.Converter(ctx), f))
+	wfState.TrackFuture(scheduleEventID, workflowstate.AsDecodingSettable(contextvalue.Converter(ctx), fmt.Sprintf("timer:%v", delay), f))
 
 	cancelReceiver := &sync.Receiver[struct{}]{
 		Receive: func(v struct{}, ok bool) {

--- a/workflow/timer_test.go
+++ b/workflow/timer_test.go
@@ -42,7 +42,7 @@ func Test_Timer_Cancellation(t *testing.T) {
 	cmd.Done()
 	fs, ok := state.FutureByScheduleEventID(1)
 	require.True(t, ok)
-	fs(nil, nil)
+	fs.Set(nil, nil)
 
 	c.Execute()
 	require.False(t, c.Finished())


### PR DESCRIPTION
With this change, pending futures are tracked with a name. When a workflow exits with pending futures, the names will be included in the log and the `panic`. For complicated workflows, this should make it clearer which futures are still pending. 

With two pending workflows, the error could look like this:

```
workflow completed, but there are still pending futures: [1-subworkflow:1 2-timer:2s]
```