### PR TITLE
Ensure coroutines exit cleanly

### DIFF
--- a/internal/sync/coroutine.go
+++ b/internal/sync/coroutine.go
@@ -146,11 +146,16 @@ func (s *coState) yield(markBlocking bool) {
 
 	s.logger.Println("yielded")
 
+	// Wait for the next Execute() call
 	<-s.unblock
+
+	// Once we're here, another Execute() call has been made. s.blocking is empty
+
 	if s.shouldExit.Load() != nil {
-		s.logger.Println("shouldExit")
-		s.blocking <- true
-		s.logger.Println("goexit")
+		s.logger.Println("exiting")
+
+		// Goexit runs all deferred functions, which includes calling finish() in the main
+		// execution function. That marks the coroutine as finished and blocking.
 		runtime.Goexit()
 	}
 

--- a/internal/sync/coroutine_test.go
+++ b/internal/sync/coroutine_test.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"errors"
+	"runtime"
 	"testing"
 	"time"
 
@@ -119,15 +120,16 @@ func Test_Coroutine_Exit(t *testing.T) {
 		return nil
 	})
 
+	r := runtime.NumGoroutine()
 	c.Exit()
 
 	require.True(t, c.Finished())
+	require.Equal(t, r-1, runtime.NumGoroutine())
 }
 
 func Test_Coroutine_ExitIfAlreadyFinished(t *testing.T) {
 	c := NewCoroutine(Background(), func(ctx Context) error {
-		// Complete immedeiately
-
+		// Complete immediately
 		return nil
 	})
 


### PR DESCRIPTION
Ensure coroutines exit cleanly and don't try to block before. 