### PR TITLE
define redis globals for vscode lua language server diagnostics

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,4 +15,10 @@
   ],
   "go.testExplorer.showDynamicSubtestsInEditor": true,
   "go.lintTool": "golangci-lint",
+  "Lua.diagnostics.globals": [
+    "KEYS",
+    "ARGV",
+    "redis",
+    "cjson"
+  ]
 }


### PR DESCRIPTION
This is a small QoL improvement for redis script static diagnostics, helping to remove noise when using the lua language server vscode extension.

## Changes
* define redis script globals in lua language server vscode settings