### PR TITLE
Fix waitgroup when waiting after Done

### DIFF
--- a/internal/sync/waitgroup.go
+++ b/internal/sync/waitgroup.go
@@ -37,11 +37,7 @@ func (wg *waitGroup) Add(delta int) {
 		panic("WaitGroup misuse: Add called concurrently with Wait")
 	}
 
-	if wg.n > 0 || !wg.waiting {
-		return
-	}
-
-	if wg.n == 0 {
+	if delta < 0 && wg.n == 0 {
 		wg.f.Set(struct{}{}, nil)
 	}
 }

--- a/internal/sync/waitgroup_test.go
+++ b/internal/sync/waitgroup_test.go
@@ -14,6 +14,25 @@ func Test_WaitGroup_PanicsForInvalidCounters(t *testing.T) {
 	})
 }
 
+func Test_WaitGroup_WaitAfterdone(t *testing.T) {
+	s := NewScheduler()
+	ctx := Background()
+
+	wg := NewWaitGroup()
+	wg.Add(2)
+	wg.Done()
+	wg.Done()
+
+	s.NewCoroutine(ctx, func(ctx Context) error {
+		wg.Wait(ctx)
+
+		return nil
+	})
+
+	s.Execute()
+	require.Equal(t, 0, s.RunningCoroutines())
+}
+
 func Test_WaitGroup_Blocks(t *testing.T) {
 	s := NewScheduler()
 	ctx := Background()


### PR DESCRIPTION
When `Wait`-ing on the wait group after the wait counter was set to `0` already, the `Wait` would never return