### PR TITLE
feat(tester): cancel workflow instance

### DIFF
--- a/tester/tester_subworkflow_test.go
+++ b/tester/tester_subworkflow_test.go
@@ -3,6 +3,7 @@ package tester
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -106,6 +107,47 @@ func Test_SubWorkflow_Mocked_Failure(t *testing.T) {
 	require.Equal(t, "", wfR)
 	require.EqualError(t, wfE, "swf error")
 
+	tester.AssertExpectations(t)
+}
+
+func Test_SubWorkflow_Cancel(t *testing.T) {
+	subWorkflow := func(ctx workflow.Context) error {
+		_, _ = ctx.Done().Receive(ctx)
+		return ctx.Err()
+	}
+
+	workflowWithSub := func(ctx workflow.Context) error {
+		_, err := workflow.CreateSubWorkflowInstance[any](
+			ctx,
+			workflow.DefaultSubWorkflowOptions,
+			subWorkflow,
+		).Get(ctx)
+		if err != nil {
+			return fmt.Errorf("subworkflow: %w", err)
+		}
+
+		return nil
+	}
+
+	tester := NewWorkflowTester[string](workflowWithSub)
+	tester.Registry().RegisterWorkflow(subWorkflow)
+
+	var subWorkflowInstance *core.WorkflowInstance
+
+	tester.ListenSubWorkflow(func(instance *core.WorkflowInstance, _ string) {
+		subWorkflowInstance = instance
+	})
+
+	tester.ScheduleCallback(time.Millisecond, func() {
+		require.NoError(t, tester.CancelWorkflowInstance(subWorkflowInstance))
+	})
+
+	tester.Execute(context.Background())
+
+	require.True(t, tester.WorkflowFinished())
+
+	_, err := tester.WorkflowResult()
+	require.EqualError(t, err, "subworkflow: context canceled")
 	tester.AssertExpectations(t)
 }
 


### PR DESCRIPTION
This allows testing of canceled workflow contexts, and seemed to be needed.  Please correct me if I'm wrong.