### PR TITLE
feat(tester): add WithInitialTime option

### DIFF
--- a/tester/options.go
+++ b/tester/options.go
@@ -13,6 +13,7 @@ type options struct {
 	Logger      *slog.Logger
 	Converter   converter.Converter
 	Propagators []workflow.ContextPropagator
+	InitialTime time.Time
 }
 
 type WorkflowTesterOption func(*options)
@@ -38,5 +39,11 @@ func WithContextPropagator(prop workflow.ContextPropagator) WorkflowTesterOption
 func WithTestTimeout(timeout time.Duration) WorkflowTesterOption {
 	return func(o *options) {
 		o.TestTimeout = timeout
+	}
+}
+
+func WithInitialTime(t time.Time) WorkflowTesterOption {
+	return func(o *options) {
+		o.InitialTime = t
 	}
 }

--- a/tester/tester.go
+++ b/tester/tester.go
@@ -187,13 +187,6 @@ func NewWorkflowTester[TResult any](workflow workflow.Workflow, opts ...Workflow
 		panic(fmt.Sprintf("workflow return type does not match: %s", err))
 	}
 
-	// Start with the current wall-c time
-	c := clock.NewMock()
-	c.Set(time.Now())
-
-	wfi := core.NewWorkflowInstance(uuid.NewString(), uuid.NewString())
-	registry := registry.New()
-
 	options := &options{
 		TestTimeout: time.Second * 10,
 		Logger:      slog.Default(),
@@ -203,6 +196,17 @@ func NewWorkflowTester[TResult any](workflow workflow.Workflow, opts ...Workflow
 	for _, o := range opts {
 		o(options)
 	}
+
+	// Start with the current wall-c time unless InitialTime is set
+	c := clock.NewMock()
+	if options.InitialTime.IsZero() {
+		c.Set(time.Now())
+	} else {
+		c.Set(options.InitialTime)
+	}
+
+	wfi := core.NewWorkflowInstance(uuid.NewString(), uuid.NewString())
+	registry := registry.New()
 
 	tracer := noop.NewTracerProvider().Tracer("workflow-tester")
 

--- a/tester/tester_test.go
+++ b/tester/tester_test.go
@@ -269,3 +269,18 @@ func waitForSignal(ctx workflow.Context) (int, error) {
 
 	return 42, nil
 }
+
+func Test_WithInitialTime(t *testing.T) {
+	getTimeWorkflow := func(ctx workflow.Context) (time.Time, error) {
+		return workflow.Now(ctx), nil
+	}
+
+	initialTime := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
+	tester := NewWorkflowTester[time.Time](getTimeWorkflow, WithInitialTime(initialTime))
+
+	tester.Execute(context.Background())
+
+	require.True(t, tester.WorkflowFinished())
+	r, _ := tester.WorkflowResult()
+	require.Equal(t, initialTime, r)
+}


### PR DESCRIPTION
This PR resolves #370.

This option sets the initial mocked time for a workflow tester to enable testing date- and/or time-of-day-dependent behavior.