### PR TITLE
Support max history size

### DIFF
--- a/backend/metrics/metrics.go
+++ b/backend/metrics/metrics.go
@@ -5,13 +5,18 @@ import "time"
 type Tags map[string]string
 
 type Client interface {
+	//Counter records a value at a point in time.
 	Counter(name string, tags Tags, value int64)
 
+	// Distribution records a value at a point in time.
 	Distribution(name string, tags Tags, value float64)
 
+	// Gauge records a value at a point in time.
 	Gauge(name string, tags Tags, value int64)
 
+	// Timing records the duration of an event.
 	Timing(name string, tags Tags, duration time.Duration)
 
+	// WithTags returns a new client with the given tags applied to all metrics.
 	WithTags(tags Tags) Client
 }

--- a/backend/options.go
+++ b/backend/options.go
@@ -43,6 +43,9 @@ type Options struct {
 	// removed immediately, including their history. If set to false, the instance will be removed after the configured
 	// retention period or never.
 	RemoveContinuedAsNewInstances bool
+
+	// MaxHistorySize is the maximum size of a workflow history. If a workflow exceeds this size, it will be failed.
+	MaxHistorySize int64
 }
 
 var DefaultOptions Options = Options{
@@ -58,6 +61,8 @@ var DefaultOptions Options = Options{
 	ContextPropagators: []workflow.ContextPropagator{&propagators.TracingContextPropagator{}},
 
 	RemoveContinuedAsNewInstances: false,
+
+	MaxHistorySize: 10_000,
 }
 
 type BackendOption func(*Options)
@@ -101,6 +106,12 @@ func WithContextPropagator(prop workflow.ContextPropagator) BackendOption {
 func WithRemoveContinuedAsNewInstances() BackendOption {
 	return func(o *Options) {
 		o.RemoveContinuedAsNewInstances = true
+	}
+}
+
+func WithMaxHistorySize(size int64) BackendOption {
+	return func(o *Options) {
+		o.MaxHistorySize = size
 	}
 }
 

--- a/internal/worker/workflow.go
+++ b/internal/worker/workflow.go
@@ -180,6 +180,7 @@ func (wtw *WorkflowTaskWorker) getExecutor(ctx context.Context, t *backend.Workf
 			t.WorkflowInstance,
 			t.Metadata,
 			clock.New(),
+			wtw.backend.Options().MaxHistorySize,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("creating workflow task executor: %w", err)

--- a/tester/options.go
+++ b/tester/options.go
@@ -9,11 +9,12 @@ import (
 )
 
 type options struct {
-	TestTimeout time.Duration
-	Logger      *slog.Logger
-	Converter   converter.Converter
-	Propagators []workflow.ContextPropagator
-	InitialTime time.Time
+	TestTimeout    time.Duration
+	Logger         *slog.Logger
+	Converter      converter.Converter
+	Propagators    []workflow.ContextPropagator
+	InitialTime    time.Time
+	MaxHistorySize int64
 }
 
 type WorkflowTesterOption func(*options)
@@ -45,5 +46,11 @@ func WithTestTimeout(timeout time.Duration) WorkflowTesterOption {
 func WithInitialTime(t time.Time) WorkflowTesterOption {
 	return func(o *options) {
 		o.InitialTime = t
+	}
+}
+
+func WithMaxHistorySize(size int64) WorkflowTesterOption {
+	return func(o *options) {
+		o.MaxHistorySize = size
 	}
 }

--- a/tester/tester.go
+++ b/tester/tester.go
@@ -194,9 +194,10 @@ func NewWorkflowTester[TResult any](workflow workflow.Workflow, opts ...Workflow
 	}
 
 	options := &options{
-		TestTimeout: time.Second * 10,
-		Logger:      slog.Default(),
-		Converter:   converter.DefaultConverter,
+		TestTimeout:    time.Second * 10,
+		Logger:         slog.Default(),
+		Converter:      converter.DefaultConverter,
+		MaxHistorySize: 10_000,
 	}
 
 	for _, o := range opts {
@@ -357,7 +358,18 @@ func (wt *workflowTester[TResult]) Execute(ctx context.Context, args ...any) {
 			tw.pendingEvents = tw.pendingEvents[:0]
 
 			// Execute task
-			e, err := executor.NewExecutor(wt.logger, wt.tracer, wt.registry, wt.converter, wt.propagators, &testHistoryProvider{tw.history}, tw.instance, tw.metadata, wt.clock)
+			e, err := executor.NewExecutor(
+				wt.logger,
+				wt.tracer,
+				wt.registry,
+				wt.converter,
+				wt.propagators,
+				&testHistoryProvider{tw.history},
+				tw.instance,
+				tw.metadata,
+				wt.clock,
+				wt.options.MaxHistorySize,
+			)
 			if err != nil {
 				panic(fmt.Errorf("could not create workflow executor: %v", err))
 			}

--- a/workflow/executor/cache/cache_test.go
+++ b/workflow/executor/cache/cache_test.go
@@ -31,6 +31,7 @@ func Test_Cache_StoreAndGet(t *testing.T) {
 	e, err := executor.NewExecutor(
 		slog.Default(), noop.NewTracerProvider().Tracer(backend.TracerName), r, converter.DefaultConverter,
 		[]workflow.ContextPropagator{}, &testHistoryProvider{}, i, &metadata.WorkflowMetadata{}, clock.New(),
+		10_000,
 	)
 	require.NoError(t, err)
 
@@ -38,6 +39,7 @@ func Test_Cache_StoreAndGet(t *testing.T) {
 	e2, err := executor.NewExecutor(
 		slog.Default(), noop.NewTracerProvider().Tracer(backend.TracerName), r, converter.DefaultConverter,
 		[]workflow.ContextPropagator{}, &testHistoryProvider{}, i, &metadata.WorkflowMetadata{}, clock.New(),
+		10_000,
 	)
 	require.NoError(t, err)
 
@@ -72,6 +74,7 @@ func Test_Cache_AutoEviction(t *testing.T) {
 		slog.Default(), noop.NewTracerProvider().Tracer(backend.TracerName), r,
 		converter.DefaultConverter, []workflow.ContextPropagator{}, &testHistoryProvider{}, i,
 		&metadata.WorkflowMetadata{}, clock.New(),
+		10_000,
 	)
 	require.NoError(t, err)
 
@@ -102,6 +105,7 @@ func Test_Cache_Evict(t *testing.T) {
 		slog.Default(), noop.NewTracerProvider().Tracer(backend.TracerName), r,
 		converter.DefaultConverter, []workflow.ContextPropagator{}, &testHistoryProvider{}, i,
 		&metadata.WorkflowMetadata{}, clock.New(),
+		10_000,
 	)
 	require.NoError(t, err)
 

--- a/workflow/executor/executor_test.go
+++ b/workflow/executor/executor_test.go
@@ -39,7 +39,7 @@ func newExecutor(r *registry.Registry, i *core.WorkflowInstance, historyProvider
 	logger := slog.Default()
 	tracer := noop.NewTracerProvider().Tracer("test")
 
-	e, err := NewExecutor(logger, tracer, r, converter.DefaultConverter, []wf.ContextPropagator{}, historyProvider, i, &metadata.WorkflowMetadata{}, clock.New())
+	e, err := NewExecutor(logger, tracer, r, converter.DefaultConverter, []wf.ContextPropagator{}, historyProvider, i, &metadata.WorkflowMetadata{}, clock.New(), 10_000)
 
 	return e.(*executor), err
 }


### PR DESCRIPTION
Add a hard-limit for workflow history sizes. Defaults to 10k events. 

Closes: https://github.com/cschleiden/go-workflows/issues/207