### PR TITLE
Fix redis NOGROUP errors when running samples

### DIFF
--- a/backend/redis/redis.go
+++ b/backend/redis/redis.go
@@ -159,7 +159,7 @@ func (rb *redisBackend) FeatureSupported(feature backend.Feature) bool {
 // to prevent NOGROUP errors when the worker starts and tries to recover abandoned tasks
 func (rb *redisBackend) ensureDefaultConsumerGroups(ctx context.Context) error {
 	// Initialize consumer groups for both default and system queues
-	queues := []workflow.Queue{core.QueueDefault, core.QueueSystem}
+	queues := []core.Queue{core.QueueDefault, core.QueueSystem}
 
 	// Prepare workflow queue consumer groups
 	if err := rb.workflowQueue.Prepare(ctx, rb.rdb, queues); err != nil {

--- a/backend/redis/redis.go
+++ b/backend/redis/redis.go
@@ -159,7 +159,7 @@ func (rb *redisBackend) FeatureSupported(feature backend.Feature) bool {
 // to prevent NOGROUP errors when the worker starts and tries to recover abandoned tasks
 func (rb *redisBackend) ensureDefaultConsumerGroups(ctx context.Context) error {
 	// Initialize consumer groups for both default and system queues
-	queues := []workflow.Queue{workflow.QueueDefault, core.QueueSystem}
+	queues := []workflow.Queue{core.QueueDefault, core.QueueSystem}
 
 	// Prepare workflow queue consumer groups
 	if err := rb.workflowQueue.Prepare(ctx, rb.rdb, queues); err != nil {


### PR DESCRIPTION
Running the samples that use redis where workers are separate generates non-stop errors like the following:

2025/09/15 23:01:02 ERROR error polling task error="dequeueing task: NOGROUP No such key 'task-stream:system:activities' or consumer group 'task-workers' in XREADGROUP with GROUP option"

The original error occurred because:

* The worker tries to recover abandoned tasks during startup using XAUTOCLAIM
* This requires existing consumer groups for the Redis streams
* Previously, consumer groups were only created when PrepareWorkflowQueues/PrepareActivityQueues were explicitly called
* The recovery operations happened before queue preparation, causing NOGROUP errors

The fix ensures that consumer groups for the essential queues (default and _system_) are created automatically during Redis backend initialization, eliminating the race condition.