### PR TITLE
Update GetBackend calls to include clear option for backend initialization

### DIFF
--- a/samples/activity-registration/activity-registration.go
+++ b/samples/activity-registration/activity-registration.go
@@ -20,7 +20,7 @@ import (
 func main() {
 	ctx := context.Background()
 
-	b := samples.GetBackend("activity-registration")
+	b := samples.GetBackend("activity-registration", true)
 
 	go RunWorker(ctx, b)
 

--- a/samples/cancellation/cancellation.go
+++ b/samples/cancellation/cancellation.go
@@ -20,7 +20,7 @@ func main() {
 	ctx := context.Background()
 	ctx, cancel := context.WithCancel(ctx)
 
-	b := samples.GetBackend("cancellation")
+	b := samples.GetBackend("cancellation", true)
 
 	// Run worker
 	go RunWorker(ctx, b)

--- a/samples/complex-parameters/complex-parameters.go
+++ b/samples/complex-parameters/complex-parameters.go
@@ -17,7 +17,7 @@ import (
 func main() {
 	ctx := context.Background()
 
-	b := samples.GetBackend("complex-parameters")
+	b := samples.GetBackend("complex-parameters", true)
 
 	// Run worker
 	go RunWorker(ctx, b)

--- a/samples/concurrent/concurrent.go
+++ b/samples/concurrent/concurrent.go
@@ -18,7 +18,7 @@ import (
 func main() {
 	ctx := context.Background()
 
-	b := samples.GetBackend("concurrent")
+	b := samples.GetBackend("concurrent", true)
 
 	// Run worker
 	go RunWorker(ctx, b)

--- a/samples/context-propagation/context_propagation.go
+++ b/samples/context-propagation/context_propagation.go
@@ -16,7 +16,7 @@ import (
 func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 
-	b := samples.GetBackend("simple", backend.WithContextPropagator(&myPropagator{}))
+	b := samples.GetBackend("simple", true, backend.WithContextPropagator(&myPropagator{}))
 
 	// Run worker
 	w := RunWorker(ctx, b)

--- a/samples/continue-as-new/continue-as-new.go
+++ b/samples/continue-as-new/continue-as-new.go
@@ -20,7 +20,7 @@ import (
 func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 
-	b := samples.GetBackend("continue-as-new")
+	b := samples.GetBackend("continue-as-new", true)
 
 	db, ok := b.(diag.Backend)
 	if !ok {

--- a/samples/converter/converter.go
+++ b/samples/converter/converter.go
@@ -41,7 +41,7 @@ func (*CustomConverter) To(v interface{}) (payload.Payload, error) {
 func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 
-	b := samples.GetBackend("converter", backend.WithConverter(&CustomConverter{}))
+	b := samples.GetBackend("converter", true, backend.WithConverter(&CustomConverter{}))
 
 	// Run worker
 	w := RunWorker(ctx, b)

--- a/samples/errors/errors.go
+++ b/samples/errors/errors.go
@@ -21,7 +21,7 @@ import (
 func main() {
 	ctx := context.Background()
 
-	b := samples.GetBackend("errors")
+	b := samples.GetBackend("errors", true)
 
 	db, ok := b.(diag.Backend)
 	if !ok {

--- a/samples/orchestrator/main.go
+++ b/samples/orchestrator/main.go
@@ -18,7 +18,7 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	backend := samples.GetBackend("orchestrator", backend.WithWorkerName("orchestrator-worker"))
+	backend := samples.GetBackend("orchestrator", true, backend.WithWorkerName("orchestrator-worker"))
 
 	orchestrator := worker.NewWorkflowOrchestrator(
 		backend,

--- a/samples/queues/queues.go
+++ b/samples/queues/queues.go
@@ -27,7 +27,7 @@ var (
 func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 
-	b := samples.GetBackend("queues", backend.WithLogger(slog.Default()))
+	b := samples.GetBackend("queues", true, backend.WithLogger(slog.Default()))
 
 	db, ok := b.(diag.Backend)
 	if !ok {

--- a/samples/retries/retries.go
+++ b/samples/retries/retries.go
@@ -19,7 +19,7 @@ import (
 func main() {
 	ctx := context.Background()
 
-	b := samples.GetBackend("retries")
+	b := samples.GetBackend("retries", true)
 
 	// Run worker
 	go RunWorker(ctx, b)

--- a/samples/runner.go
+++ b/samples/runner.go
@@ -16,7 +16,7 @@ import (
 	redisv9 "github.com/redis/go-redis/v9"
 )
 
-func GetBackend(name string, opt ...backend.BackendOption) backend.Backend {
+func GetBackend(name string, clear bool, opt ...backend.BackendOption) backend.Backend {
 	b := flag.String("backend", "redis", "backend to use: memory, sqlite, mysql, redis")
 	flag.Parse()
 
@@ -53,7 +53,9 @@ func GetBackend(name string, opt ...backend.BackendOption) backend.Backend {
 			ReadTimeout:  time.Second * 30,
 		})
 
-		rclient.FlushAll(context.Background()).Result()
+		if clear {
+			rclient.FlushAll(context.Background()).Result()
+		}
 
 		b, err := redis.NewRedisBackend(rclient, redis.WithBackendOptions(opt...))
 		if err != nil {

--- a/samples/runner.go
+++ b/samples/runner.go
@@ -16,7 +16,7 @@ import (
 	redisv9 "github.com/redis/go-redis/v9"
 )
 
-func GetBackend(name string, clear bool, opt ...backend.BackendOption) backend.Backend {
+func GetBackend(name string, recreate bool, opt ...backend.BackendOption) backend.Backend {
 	b := flag.String("backend", "redis", "backend to use: memory, sqlite, mysql, redis")
 	flag.Parse()
 
@@ -53,7 +53,7 @@ func GetBackend(name string, clear bool, opt ...backend.BackendOption) backend.B
 			ReadTimeout:  time.Second * 30,
 		})
 
-		if clear {
+		if recreate {
 			rclient.FlushAll(context.Background()).Result()
 		}
 

--- a/samples/scale/starter/main.go
+++ b/samples/scale/starter/main.go
@@ -19,7 +19,7 @@ var count int32
 
 func main() {
 	ctx := context.Background()
-	b := samples.GetBackend("scale")
+	b := samples.GetBackend("scale", false)
 
 	count = int32(*tostart)
 

--- a/samples/scale/worker/main.go
+++ b/samples/scale/worker/main.go
@@ -18,7 +18,7 @@ func main() {
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	b := samples.GetBackend("scale")
+	b := samples.GetBackend("scale", false)
 
 	// Run worker
 	go RunWorker(ctx, b)

--- a/samples/signal-subworkflow/subworkflow-signal.go
+++ b/samples/signal-subworkflow/subworkflow-signal.go
@@ -18,7 +18,7 @@ import (
 func main() {
 	ctx := context.Background()
 
-	b := samples.GetBackend("subworkflow-signal")
+	b := samples.GetBackend("subworkflow-signal", true)
 
 	// Run worker
 	go RunWorker(ctx, b)

--- a/samples/signal/signal.go
+++ b/samples/signal/signal.go
@@ -18,7 +18,7 @@ import (
 func main() {
 	ctx := context.Background()
 
-	b := samples.GetBackend("signal")
+	b := samples.GetBackend("signal", true)
 
 	// Run worker
 	go RunWorker(ctx, b)

--- a/samples/simple-split-worker/starter/main.go
+++ b/samples/simple-split-worker/starter/main.go
@@ -13,7 +13,7 @@ import (
 func main() {
 	ctx := context.Background()
 
-	b := samples.GetBackend("simple-split")
+	b := samples.GetBackend("simple-split", false)
 
 	// Start workflow via client
 	c := client.New(b)

--- a/samples/simple-split-worker/worker/main.go
+++ b/samples/simple-split-worker/worker/main.go
@@ -14,7 +14,7 @@ import (
 func main() {
 	ctx := context.Background()
 
-	b := samples.GetBackend("simple-split")
+	b := samples.GetBackend("simple-split", false)
 
 	// Run worker
 	go RunWorker(ctx, b)

--- a/samples/simple/simple.go
+++ b/samples/simple/simple.go
@@ -16,7 +16,7 @@ import (
 func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 
-	b := samples.GetBackend("simple")
+	b := samples.GetBackend("simple", true)
 
 	// Run worker
 	w := RunWorker(ctx, b)

--- a/samples/subworkflow/subworkflow.go
+++ b/samples/subworkflow/subworkflow.go
@@ -18,7 +18,7 @@ import (
 func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 
-	b := samples.GetBackend("subworkflow")
+	b := samples.GetBackend("subworkflow", true)
 
 	// Run worker
 	w := RunWorker(ctx, b)

--- a/samples/timer/timer.go
+++ b/samples/timer/timer.go
@@ -18,7 +18,7 @@ func main() {
 	ctx := context.Background()
 	ctx, cancel := context.WithCancel(ctx)
 
-	b := samples.GetBackend("timer")
+	b := samples.GetBackend("timer", true)
 
 	// Run worker
 	w := RunWorker(ctx, b)

--- a/samples/tracing/tracing.go
+++ b/samples/tracing/tracing.go
@@ -60,7 +60,7 @@ func main() {
 
 	otel.SetTracerProvider(tp)
 
-	b := samples.GetBackend("tracing",
+	b := samples.GetBackend("tracing", true,
 		backend.WithTracerProvider(tp),
 		backend.WithStickyTimeout(0),
 	)

--- a/samples/web/web.go
+++ b/samples/web/web.go
@@ -21,7 +21,7 @@ import (
 func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 
-	b := samples.GetBackend("web")
+	b := samples.GetBackend("web", true)
 
 	db, ok := b.(diag.Backend)
 	if !ok {

--- a/samples/workflow-registration/workflow_registration.go
+++ b/samples/workflow-registration/workflow_registration.go
@@ -17,7 +17,7 @@ import (
 func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 
-	b := samples.GetBackend("simple")
+	b := samples.GetBackend("simple", true)
 
 	// Run worker
 	w := RunWorker(ctx, b)


### PR DESCRIPTION
Only clear the backend state (Flush for Redis) for samples that do not have a split worker and starter.