### PR TITLE
Allow For Configuration of SSL Mode With the Postgres Backend

### DIFF
--- a/backend/postgres/options.go
+++ b/backend/postgres/options.go
@@ -13,6 +13,10 @@ type options struct {
 
 	// ApplyMigrations automatically applies database migrations on startup.
 	ApplyMigrations bool
+
+	// SSLMode configures the sslmode parameter for the PostgreSQL connection.
+	// Defaults to "disable" if not set.
+	SSLMode string
 }
 
 type option func(*options)
@@ -27,6 +31,15 @@ func WithApplyMigrations(applyMigrations bool) option {
 func WithPostgresOptions(f func(db *sql.DB)) option {
 	return func(o *options) {
 		o.PostgresOptions = f
+	}
+}
+
+// WithSSLMode configures the sslmode parameter for the PostgreSQL connection string.
+// Valid values include "disable", "require", "verify-ca", "verify-full", etc.
+// Defaults to "disable" if not set.
+func WithSSLMode(sslmode string) option {
+	return func(o *options) {
+		o.SSLMode = sslmode
 	}
 }
 

--- a/backend/postgres/postgres.go
+++ b/backend/postgres/postgres.go
@@ -39,7 +39,11 @@ func NewPostgresBackend(host string, port int, user, password, database string, 
 		opt(options)
 	}
 
-	dsn := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=disable", host, port, user, password, database)
+	if options.SSLMode == "" {
+		options.SSLMode = "disable"
+	}
+
+	dsn := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=%s", host, port, user, password, database, options.SSLMode)
 
 	db, err := sql.Open("pgx", dsn)
 	if err != nil {


### PR DESCRIPTION
When the Postgres backend was building the connection string, the ssl mode was hardcoded to `disable`. This change exposes the ssl mode as a configuration option, allowing users to specify the mode themselves. 

Notes:
- Defaults "disable" if not set for backwards compatibility
- Just takes a string. Could be a bit more defensive and validate this string against known values but I thought this was an ok tradeoff as the connection will fail pretty quickly with an invalid option. 