### PR TITLE
Update sqlite RemoveWorkflowInstances performance

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -37,8 +37,8 @@ type Backend interface {
 	// RemoveWorkflowInstance removes a workflow instance
 	RemoveWorkflowInstance(ctx context.Context, instance *workflow.Instance) error
 
-	// RemoveWorkflowInstances removes multiple workflow instances
-	RemoveWorkflowInstances(ctx context.Context, options ...RemovalOption) error
+	// RemoveWorkflowInstances removes multiple workflow instances and returns the number removed
+	RemoveWorkflowInstances(ctx context.Context, options ...RemovalOption) (int, error)
 
 	// GetWorkflowInstanceState returns the state of the given workflow instance
 	GetWorkflowInstanceState(ctx context.Context, instance *workflow.Instance) (core.WorkflowInstanceState, error)

--- a/backend/mock_Backend.go
+++ b/backend/mock_Backend.go
@@ -335,7 +335,7 @@ func (_m *MockBackend) RemoveWorkflowInstance(ctx context.Context, instance *cor
 }
 
 // RemoveWorkflowInstances provides a mock function with given fields: ctx, options
-func (_m *MockBackend) RemoveWorkflowInstances(ctx context.Context, options ...RemovalOption) error {
+func (_m *MockBackend) RemoveWorkflowInstances(ctx context.Context, options ...RemovalOption) (int, error) {
 	_va := make([]interface{}, len(options))
 	for _i := range options {
 		_va[_i] = options[_i]
@@ -345,14 +345,21 @@ func (_m *MockBackend) RemoveWorkflowInstances(ctx context.Context, options ...R
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, ...RemovalOption) error); ok {
+	var r0 int
+	if rf, ok := ret.Get(0).(func(context.Context, ...RemovalOption) int); ok {
 		r0 = rf(ctx, options...)
 	} else {
-		r0 = ret.Error(0)
+		r0 = ret.Get(0).(int)
 	}
 
-	return r0
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, ...RemovalOption) error); ok {
+		r1 = rf(ctx, options...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // SignalWorkflow provides a mock function with given fields: ctx, instanceID, event

--- a/backend/mysql/mysql.go
+++ b/backend/mysql/mysql.go
@@ -201,7 +201,7 @@ func (mb *mysqlBackend) removeWorkflowInstance(ctx context.Context, instance *co
 	return nil
 }
 
-func (mb *mysqlBackend) RemoveWorkflowInstances(ctx context.Context, options ...backend.RemovalOption) error {
+func (mb *mysqlBackend) RemoveWorkflowInstances(ctx context.Context, options ...backend.RemovalOption) (int, error) {
 	ro := backend.DefaultRemovalOptions
 	for _, opt := range options {
 		opt(&ro)
@@ -209,7 +209,7 @@ func (mb *mysqlBackend) RemoveWorkflowInstances(ctx context.Context, options ...
 
 	rows, err := mb.db.QueryContext(ctx, `SELECT instance_id, execution_id FROM instances WHERE completed_at < ?`, ro.FinishedBefore)
 	if err != nil {
-		return err
+		return 0, err
 	}
 
 	instanceIDs := []string{}
@@ -217,7 +217,7 @@ func (mb *mysqlBackend) RemoveWorkflowInstances(ctx context.Context, options ...
 	for rows.Next() {
 		var id, executionID string
 		if err := rows.Scan(&id, &executionID); err != nil {
-			return err
+			return 0, err
 		}
 
 		instanceIDs = append(instanceIDs, id)
@@ -225,9 +225,10 @@ func (mb *mysqlBackend) RemoveWorkflowInstances(ctx context.Context, options ...
 	}
 
 	if rows.Err() != nil {
-		return rows.Err()
+		return 0, rows.Err()
 	}
 
+	removed := 0
 	batchSize := ro.BatchSize
 	for i := 0; i < len(instanceIDs); i += batchSize {
 		instanceIDs := instanceIDs[i:min(i+batchSize, len(instanceIDs))]
@@ -235,7 +236,7 @@ func (mb *mysqlBackend) RemoveWorkflowInstances(ctx context.Context, options ...
 
 		tx, err := mb.db.BeginTx(ctx, nil)
 		if err != nil {
-			return err
+			return removed, err
 		}
 
 		defer tx.Rollback()
@@ -252,23 +253,25 @@ func (mb *mysqlBackend) RemoveWorkflowInstances(ctx context.Context, options ...
 
 		// Delete from instances, history and attributes tables
 		if _, err := tx.ExecContext(ctx, fmt.Sprintf("DELETE FROM `instances` WHERE %v", whereCondition), args...); err != nil {
-			return err
+			return removed, err
 		}
 
 		if _, err := tx.ExecContext(ctx, fmt.Sprintf("DELETE FROM `history` WHERE %v", whereCondition), args...); err != nil {
-			return err
+			return removed, err
 		}
 
 		if _, err := tx.ExecContext(ctx, fmt.Sprintf("DELETE FROM `attributes` WHERE %v", whereCondition), args...); err != nil {
-			return err
+			return removed, err
 		}
 
 		if err := tx.Commit(); err != nil {
-			return err
+			return removed, err
 		}
+
+		removed += len(instanceIDs)
 	}
 
-	return nil
+	return removed, nil
 }
 
 func (mb *mysqlBackend) CancelWorkflowInstance(ctx context.Context, instance *workflow.Instance, event *history.Event) error {

--- a/backend/postgres/postgres.go
+++ b/backend/postgres/postgres.go
@@ -201,7 +201,7 @@ func (pb *postgresBackend) removeWorkflowInstance(ctx context.Context, instance 
 	return nil
 }
 
-func (pb *postgresBackend) RemoveWorkflowInstances(ctx context.Context, options ...backend.RemovalOption) error {
+func (pb *postgresBackend) RemoveWorkflowInstances(ctx context.Context, options ...backend.RemovalOption) (int, error) {
 	ro := backend.DefaultRemovalOptions
 	for _, opt := range options {
 		opt(&ro)
@@ -209,7 +209,7 @@ func (pb *postgresBackend) RemoveWorkflowInstances(ctx context.Context, options 
 
 	rows, err := pb.db.QueryContext(ctx, "SELECT instance_id, execution_id FROM instances WHERE completed_at < $1", ro.FinishedBefore)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	defer rows.Close()
 
@@ -220,7 +220,7 @@ func (pb *postgresBackend) RemoveWorkflowInstances(ctx context.Context, options 
 	for rows.Next() {
 		var id, executionID string
 		if err := rows.Scan(&id, &executionID); err != nil {
-			return err
+			return 0, err
 		}
 		pairs = append(pairs, struct {
 			instanceID  string
@@ -232,7 +232,7 @@ func (pb *postgresBackend) RemoveWorkflowInstances(ctx context.Context, options 
 	}
 
 	if rows.Err() != nil {
-		return rows.Err()
+		return 0, rows.Err()
 	}
 
 	pgPairedPlaceholders := func(startIdx, pairCount int) string {
@@ -243,11 +243,12 @@ func (pb *postgresBackend) RemoveWorkflowInstances(ctx context.Context, options 
 		return strings.Join(placeholders, ", ")
 	}
 
+	removed := 0
 	batchSize := ro.BatchSize
 	for i := 0; i < len(pairs); i += batchSize {
 		tx, err := pb.db.BeginTx(ctx, nil)
 		if err != nil {
-			return err
+			return removed, err
 		}
 
 		batch := pairs[i:min(i+batchSize, len(pairs))]
@@ -264,25 +265,27 @@ func (pb *postgresBackend) RemoveWorkflowInstances(ctx context.Context, options 
 		// Delete from instances, history and attributes tables
 		if _, err := tx.ExecContext(ctx, fmt.Sprintf("DELETE FROM instances WHERE %v", whereCondition), args...); err != nil {
 			_ = tx.Rollback()
-			return err
+			return removed, err
 		}
 
 		if _, err := tx.ExecContext(ctx, fmt.Sprintf("DELETE FROM history WHERE %v", whereCondition), args...); err != nil {
 			_ = tx.Rollback()
-			return err
+			return removed, err
 		}
 
 		if _, err := tx.ExecContext(ctx, fmt.Sprintf("DELETE FROM attributes WHERE %v", whereCondition), args...); err != nil {
 			_ = tx.Rollback()
-			return err
+			return removed, err
 		}
 
 		if err := tx.Commit(); err != nil {
-			return err
+			return removed, err
 		}
+
+		removed += len(batch)
 	}
 
-	return nil
+	return removed, nil
 }
 
 func (pb *postgresBackend) CancelWorkflowInstance(ctx context.Context, instance *workflow.Instance, event *history.Event) error {

--- a/backend/redis/instance.go
+++ b/backend/redis/instance.go
@@ -167,8 +167,8 @@ func (rb *redisBackend) RemoveWorkflowInstance(ctx context.Context, instance *co
 	return rb.deleteInstance(ctx, instance)
 }
 
-func (rb *redisBackend) RemoveWorkflowInstances(ctx context.Context, options ...backend.RemovalOption) error {
-	return backend.ErrNotSupported{
+func (rb *redisBackend) RemoveWorkflowInstances(ctx context.Context, options ...backend.RemovalOption) (int, error) {
+	return 0, backend.ErrNotSupported{
 		Message: "not supported, use auto-expiration",
 	}
 }

--- a/backend/removal.go
+++ b/backend/removal.go
@@ -10,7 +10,7 @@ type RemovalOptions struct {
 }
 
 var DefaultRemovalOptions = RemovalOptions{
-	BatchSize: 500,
+	BatchSize: 50,
 }
 
 type RemovalOption func(o *RemovalOptions)

--- a/backend/removal.go
+++ b/backend/removal.go
@@ -10,7 +10,7 @@ type RemovalOptions struct {
 }
 
 var DefaultRemovalOptions = RemovalOptions{
-	BatchSize: 100,
+	BatchSize: 500,
 }
 
 type RemovalOption func(o *RemovalOptions)

--- a/backend/sqlite/events.go
+++ b/backend/sqlite/events.go
@@ -31,10 +31,6 @@ func (sb *sqliteBackend) GetFutureEvents(ctx context.Context) ([]*history.Event,
 	if err != nil {
 		return nil, fmt.Errorf("getting history: %w", err)
 	}
-	if futureEvents.Err() != nil {
-		return nil, futureEvents.Err()
-	}
-
 	defer futureEvents.Close()
 
 	f := make([]*history.Event, 0)
@@ -67,6 +63,10 @@ func (sb *sqliteBackend) GetFutureEvents(ctx context.Context) ([]*history.Event,
 		fe.Attributes = a
 
 		f = append(f, fe)
+	}
+
+	if futureEvents.Err() != nil {
+		return nil, futureEvents.Err()
 	}
 
 	return f, nil
@@ -269,5 +269,5 @@ func removeFutureEvent(ctx context.Context, tx *sql.Tx, instance *core.WorkflowI
 		}
 	}
 
-	return err
+	return nil
 }

--- a/backend/sqlite/sqlite.go
+++ b/backend/sqlite/sqlite.go
@@ -97,6 +97,18 @@ func newSqliteBackend(dsn string, opts ...option) *sqliteBackend {
 		}
 	}
 
+	// Enable auto_vacuum on databases that don't have it yet. The pragma must
+	// be set before checking because PRAGMA auto_vacuum returns the on-disk
+	// value, which is 0 (none) for databases created before this change. After
+	// setting the pragma, VACUUM rewrites the file to enable auto-vacuuming.
+	// On new/empty databases this is instant; on trimmed databases it's fast.
+	var autoVacuum int
+	if err := db.QueryRow("PRAGMA auto_vacuum;").Scan(&autoVacuum); err == nil && autoVacuum == 0 {
+		if _, err := db.Exec("PRAGMA auto_vacuum = FULL; VACUUM;"); err != nil {
+			panic(fmt.Errorf("enabling auto_vacuum: %w", err))
+		}
+	}
+
 	return b
 }
 

--- a/backend/sqlite/sqlite.go
+++ b/backend/sqlite/sqlite.go
@@ -275,7 +275,7 @@ func (sb *sqliteBackend) removeWorkflowInstance(ctx context.Context, instance *c
 	return nil
 }
 
-func (sb *sqliteBackend) RemoveWorkflowInstances(ctx context.Context, options ...backend.RemovalOption) error {
+func (sb *sqliteBackend) RemoveWorkflowInstances(ctx context.Context, options ...backend.RemovalOption) (int, error) {
 	ro := backend.DefaultRemovalOptions
 	for _, opt := range options {
 		opt(&ro)
@@ -285,7 +285,7 @@ func (sb *sqliteBackend) RemoveWorkflowInstances(ctx context.Context, options ..
 		`SELECT id, execution_id FROM instances WHERE completed_at IS NOT NULL AND completed_at < ? LIMIT ?`,
 		ro.FinishedBefore, ro.BatchSize)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	defer rows.Close()
 
@@ -294,7 +294,7 @@ func (sb *sqliteBackend) RemoveWorkflowInstances(ctx context.Context, options ..
 	for rows.Next() {
 		var id, executionID string
 		if err := rows.Scan(&id, &executionID); err != nil {
-			return err
+			return 0, err
 		}
 
 		instanceIDs = append(instanceIDs, id)
@@ -302,16 +302,16 @@ func (sb *sqliteBackend) RemoveWorkflowInstances(ctx context.Context, options ..
 	}
 
 	if rows.Err() != nil {
-		return rows.Err()
+		return 0, rows.Err()
 	}
 
 	if len(instanceIDs) == 0 {
-		return nil
+		return 0, nil
 	}
 
 	tx, err := sb.db.BeginTx(ctx, nil)
 	if err != nil {
-		return err
+		return 0, err
 	}
 
 	placeholders := strings.Repeat(",?", len(instanceIDs)-1)
@@ -328,20 +328,20 @@ func (sb *sqliteBackend) RemoveWorkflowInstances(ctx context.Context, options ..
 	// Delete from instances, history and attributes tables
 	if _, err := tx.ExecContext(ctx, fmt.Sprintf("DELETE FROM `instances` WHERE %v", instancesWhere), args...); err != nil {
 		_ = tx.Rollback()
-		return err
+		return 0, err
 	}
 
 	if _, err := tx.ExecContext(ctx, fmt.Sprintf("DELETE FROM `history` WHERE %v", historyWhere), args...); err != nil {
 		_ = tx.Rollback()
-		return err
+		return 0, err
 	}
 
 	if _, err := tx.ExecContext(ctx, fmt.Sprintf("DELETE FROM `attributes` WHERE %v", historyWhere), args...); err != nil {
 		_ = tx.Rollback()
-		return err
+		return 0, err
 	}
 
-	return tx.Commit()
+	return len(instanceIDs), tx.Commit()
 }
 
 func (sb *sqliteBackend) CancelWorkflowInstance(ctx context.Context, instance *workflow.Instance, event *history.Event) error {

--- a/backend/sqlite/sqlite.go
+++ b/backend/sqlite/sqlite.go
@@ -97,18 +97,6 @@ func newSqliteBackend(dsn string, opts ...option) *sqliteBackend {
 		}
 	}
 
-	// Enable auto_vacuum on databases that don't have it yet. The pragma must
-	// be set before checking because PRAGMA auto_vacuum returns the on-disk
-	// value, which is 0 (none) for databases created before this change. After
-	// setting the pragma, VACUUM rewrites the file to enable auto-vacuuming.
-	// On new/empty databases this is instant; on trimmed databases it's fast.
-	var autoVacuum int
-	if err := db.QueryRow("PRAGMA auto_vacuum;").Scan(&autoVacuum); err == nil && autoVacuum == 0 {
-		if _, err := db.Exec("PRAGMA auto_vacuum = FULL; VACUUM;"); err != nil {
-			panic(fmt.Errorf("enabling auto_vacuum: %w", err))
-		}
-	}
-
 	return b
 }
 

--- a/backend/sqlite/sqlite.go
+++ b/backend/sqlite/sqlite.go
@@ -281,10 +281,13 @@ func (sb *sqliteBackend) RemoveWorkflowInstances(ctx context.Context, options ..
 		opt(&ro)
 	}
 
-	rows, err := sb.db.QueryContext(ctx, `SELECT id, execution_id FROM instances WHERE completed_at < ?`, ro.FinishedBefore)
+	rows, err := sb.db.QueryContext(ctx,
+		`SELECT id, execution_id FROM instances WHERE completed_at IS NOT NULL AND completed_at < ? LIMIT ?`,
+		ro.FinishedBefore, ro.BatchSize)
 	if err != nil {
 		return err
 	}
+	defer rows.Close()
 
 	instanceIDs := []string{}
 	executionIDs := []string{}
@@ -302,47 +305,43 @@ func (sb *sqliteBackend) RemoveWorkflowInstances(ctx context.Context, options ..
 		return rows.Err()
 	}
 
-	batchSize := ro.BatchSize
-	for i := 0; i < len(instanceIDs); i += batchSize {
-		instanceIDs := instanceIDs[i:min(i+batchSize, len(instanceIDs))]
-		executionIDs := executionIDs[i:min(i+batchSize, len(executionIDs))]
-
-		tx, err := sb.db.BeginTx(ctx, nil)
-		if err != nil {
-			return err
-		}
-
-		defer tx.Rollback()
-
-		placeholders := strings.Repeat(",?", len(instanceIDs)-1)
-		whereCondition := fmt.Sprintf("id IN (?%v) AND execution_id IN (?%v)", placeholders, placeholders)
-		args := make([]interface{}, 0, len(instanceIDs)*2)
-		for i := range instanceIDs {
-			args = append(args, instanceIDs[i])
-		}
-		for i := range executionIDs {
-			args = append(args, executionIDs[i])
-		}
-
-		// Delete from instances, history and attributes tables
-		if _, err := tx.ExecContext(ctx, fmt.Sprintf("DELETE FROM `instances` WHERE %v", whereCondition), args...); err != nil {
-			return err
-		}
-
-		if _, err := tx.ExecContext(ctx, fmt.Sprintf("DELETE FROM `history` WHERE %v", whereCondition), args...); err != nil {
-			return err
-		}
-
-		if _, err := tx.ExecContext(ctx, fmt.Sprintf("DELETE FROM `attributes` WHERE %v", whereCondition), args...); err != nil {
-			return err
-		}
-
-		if err := tx.Commit(); err != nil {
-			return err
-		}
+	if len(instanceIDs) == 0 {
+		return nil
 	}
 
-	return nil
+	tx, err := sb.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+
+	placeholders := strings.Repeat(",?", len(instanceIDs)-1)
+	instancesWhere := fmt.Sprintf("id IN (?%v) AND execution_id IN (?%v)", placeholders, placeholders)
+	historyWhere := fmt.Sprintf("instance_id IN (?%v) AND execution_id IN (?%v)", placeholders, placeholders)
+	args := make([]interface{}, 0, len(instanceIDs)*2)
+	for j := range instanceIDs {
+		args = append(args, instanceIDs[j])
+	}
+	for j := range executionIDs {
+		args = append(args, executionIDs[j])
+	}
+
+	// Delete from instances, history and attributes tables
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf("DELETE FROM `instances` WHERE %v", instancesWhere), args...); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf("DELETE FROM `history` WHERE %v", historyWhere), args...); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf("DELETE FROM `attributes` WHERE %v", historyWhere), args...); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+
+	return tx.Commit()
 }
 
 func (sb *sqliteBackend) CancelWorkflowInstance(ctx context.Context, instance *workflow.Instance, event *history.Event) error {

--- a/backend/sqlite/sqlite.go
+++ b/backend/sqlite/sqlite.go
@@ -254,6 +254,7 @@ func (sb *sqliteBackend) removeWorkflowInstance(ctx context.Context, instance *c
 		if err == sql.ErrNoRows {
 			return backend.ErrInstanceNotFound
 		}
+		return fmt.Errorf("scanning workflow instance state: %w", err)
 	}
 
 	if state == core.WorkflowInstanceStateActive {
@@ -409,6 +410,7 @@ func (sb *sqliteBackend) GetWorkflowInstanceState(ctx context.Context, instance 
 		if err == sql.ErrNoRows {
 			return core.WorkflowInstanceStateActive, backend.ErrInstanceNotFound
 		}
+		return core.WorkflowInstanceStateActive, fmt.Errorf("scanning workflow instance state: %w", err)
 	}
 
 	return state, nil
@@ -424,8 +426,11 @@ func (sb *sqliteBackend) SignalWorkflow(ctx context.Context, instanceID string, 
 	// TODO: Combine this with the event insertion
 	var executionID string
 	res := tx.QueryRowContext(ctx, "SELECT execution_id FROM `instances` WHERE id = ? AND state = ? LIMIT 1", instanceID, core.WorkflowInstanceStateActive)
-	if err := res.Scan(&executionID); err == sql.ErrNoRows {
-		return backend.ErrInstanceNotFound
+	if err := res.Scan(&executionID); err != nil {
+		if err == sql.ErrNoRows {
+			return backend.ErrInstanceNotFound
+		}
+		return fmt.Errorf("scanning execution ID: %w", err)
 	}
 
 	if err := insertPendingEvents(ctx, tx, core.NewWorkflowInstance(instanceID, executionID), []*history.Event{event}); err != nil {

--- a/backend/sqlite/stats.go
+++ b/backend/sqlite/stats.go
@@ -57,6 +57,7 @@ func (sb *sqliteBackend) GetStats(ctx context.Context) (*backend.Stats, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to query active instances: %w", err)
 	}
+	defer workflowRows.Close()
 
 	s.PendingWorkflowTasks = make(map[core.Queue]int64)
 
@@ -81,6 +82,7 @@ func (sb *sqliteBackend) GetStats(ctx context.Context) (*backend.Stats, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to query active activities: %w", err)
 	}
+	defer activityRows.Close()
 
 	s.PendingActivityTasks = make(map[core.Queue]int64)
 

--- a/backend/test/e2e_removal.go
+++ b/backend/test/e2e_removal.go
@@ -30,7 +30,7 @@ var e2eRemovalTests = []backendTest{
 			for i := 0; i < 10; i++ {
 				time.Sleep(300 * time.Millisecond)
 
-				err = b.RemoveWorkflowInstances(ctx, backend.RemoveFinishedBefore(time.Now()))
+				_, err = b.RemoveWorkflowInstances(ctx, backend.RemoveFinishedBefore(time.Now()))
 				if errors.As(err, &backend.ErrNotSupported{}) {
 					t.Skip()
 					return
@@ -72,7 +72,7 @@ var e2eRemovalTests = []backendTest{
 			for i := 0; i < 10; i++ {
 				time.Sleep(300 * time.Millisecond)
 
-				err = b.RemoveWorkflowInstances(ctx, backend.RemoveFinishedBefore(time.Now()))
+				_, err = b.RemoveWorkflowInstances(ctx, backend.RemoveFinishedBefore(time.Now()))
 				if errors.As(err, &backend.ErrNotSupported{}) {
 					t.Skip()
 					return

--- a/backend/test/e2e_removal.go
+++ b/backend/test/e2e_removal.go
@@ -48,6 +48,53 @@ var e2eRemovalTests = []backendTest{
 		},
 	},
 	{
+		name: "RemoveWorkflowInstances/CleansUpHistoryAndAttributes",
+		f: func(t *testing.T, ctx context.Context, c *client.Client, w *worker.Worker, b TestBackend) {
+			a := func(ctx context.Context) (int, error) {
+				return 42, nil
+			}
+			wf := func(ctx workflow.Context) (int, error) {
+				return workflow.ExecuteActivity[int](ctx, workflow.DefaultActivityOptions, a).Get(ctx)
+			}
+
+			register(t, ctx, w, []interface{}{wf}, []interface{}{a})
+
+			instance := runWorkflow(t, ctx, c, wf)
+			_, err := client.GetWorkflowResult[int](ctx, c, instance, time.Second*10)
+			require.NoError(t, err)
+
+			// Verify history exists before removal
+			h, err := b.GetWorkflowInstanceHistory(ctx, instance, nil)
+			require.NoError(t, err)
+			require.NotEmpty(t, h, "history should exist before removal")
+
+			// Remove workflow instances
+			for i := 0; i < 10; i++ {
+				time.Sleep(300 * time.Millisecond)
+
+				err = b.RemoveWorkflowInstances(ctx, backend.RemoveFinishedBefore(time.Now()))
+				if errors.As(err, &backend.ErrNotSupported{}) {
+					t.Skip()
+					return
+				}
+
+				require.NoError(t, err)
+
+				_, err = c.GetWorkflowInstanceState(ctx, instance)
+				if errors.Is(err, backend.ErrInstanceNotFound) {
+					break
+				}
+			}
+
+			require.ErrorIs(t, err, backend.ErrInstanceNotFound)
+
+			// Verify history and attributes are also cleaned up
+			h, err = b.GetWorkflowInstanceHistory(ctx, instance, nil)
+			require.NoError(t, err)
+			require.Empty(t, h, "history and attributes should be removed along with instance")
+		},
+	},
+	{
 		name: "AutoExpiration/StartsWorkflowAndRemoves",
 		f: func(t *testing.T, ctx context.Context, c *client.Client, w *worker.Worker, b TestBackend) {
 			wf := func(ctx workflow.Context) (bool, error) {

--- a/client/client.go
+++ b/client/client.go
@@ -284,7 +284,7 @@ func (c *Client) RemoveWorkflowInstance(ctx context.Context, instance *core.Work
 }
 
 // RemoveWorkflowInstances removes completed workflow instances from the backend.
-func (c *Client) RemoveWorkflowInstances(ctx context.Context, options ...backend.RemovalOption) error {
+func (c *Client) RemoveWorkflowInstances(ctx context.Context, options ...backend.RemovalOption) (int, error) {
 	ctx, span := c.backend.Tracer().Start(ctx, "RemoveWorkflowInstances")
 	defer span.End()
 

--- a/internal/command/cancelablecommand.go
+++ b/internal/command/cancelablecommand.go
@@ -29,6 +29,8 @@ func (c *cancelableCommand) HandleCancel() {
 	switch c.state {
 	case CommandState_CancelPending:
 		c.state = CommandState_Canceled
+	case CommandState_Done:
+		c.state = CommandState_Done
 	default:
 		c.invalidStateTransition(CommandState_Canceled)
 	}
@@ -36,7 +38,7 @@ func (c *cancelableCommand) HandleCancel() {
 
 func (c *cancelableCommand) Done() {
 	switch c.state {
-	case CommandState_Committed, CommandState_Canceled:
+	case CommandState_Committed, CommandState_CancelPending, CommandState_Canceled:
 		c.state = CommandState_Done
 		if c.whenDone != nil {
 			c.whenDone()

--- a/internal/command/schedule_subworkflow_test.go
+++ b/internal/command/schedule_subworkflow_test.go
@@ -4,12 +4,13 @@ import (
 	"testing"
 
 	"github.com/benbjohnson/clock"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
 	"github.com/cschleiden/go-workflows/backend/history"
 	"github.com/cschleiden/go-workflows/backend/metadata"
 	"github.com/cschleiden/go-workflows/backend/payload"
 	"github.com/cschleiden/go-workflows/core"
-	"github.com/google/uuid"
-	"github.com/stretchr/testify/require"
 )
 
 func TestScheduleSubWorkflowCommand_StateTransitions(t *testing.T) {
@@ -68,6 +69,17 @@ func TestScheduleSubWorkflowCommand_StateTransitions(t *testing.T) {
 			c.Commit()
 
 			c.Done()
+			require.Equal(t, CommandState_Done, c.State())
+		}},
+		{"Done_while_cancel_pending", func(t *testing.T, c *ScheduleSubWorkflowCommand, clock clock.Clock) {
+			c.Commit()
+			c.Cancel()
+			require.Equal(t, CommandState_CancelPending, c.State())
+
+			c.Done()
+			require.Equal(t, CommandState_Done, c.State())
+			
+			c.HandleCancel()
 			require.Equal(t, CommandState_Done, c.State())
 		}},
 		{"Done_after_cancel", func(t *testing.T, c *ScheduleSubWorkflowCommand, clock clock.Clock) {

--- a/internal/command/schedule_subworkflow_test.go
+++ b/internal/command/schedule_subworkflow_test.go
@@ -78,7 +78,7 @@ func TestScheduleSubWorkflowCommand_StateTransitions(t *testing.T) {
 
 			c.Done()
 			require.Equal(t, CommandState_Done, c.State())
-			
+
 			c.HandleCancel()
 			require.Equal(t, CommandState_Done, c.State())
 		}},

--- a/internal/command/schedule_timer_test.go
+++ b/internal/command/schedule_timer_test.go
@@ -5,8 +5,9 @@ import (
 	"time"
 
 	"github.com/benbjohnson/clock"
-	"github.com/cschleiden/go-workflows/backend/history"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cschleiden/go-workflows/backend/history"
 )
 
 func TestScheduleTimerCommand_StateTransitions(t *testing.T) {
@@ -69,6 +70,17 @@ func TestScheduleTimerCommand_StateTransitions(t *testing.T) {
 			c.Cancel()
 
 			c.Done()
+			require.Equal(t, CommandState_Done, c.State())
+		}},
+		{"Done_while_cancel_pending", func(t *testing.T, c *ScheduleTimerCommand, clock clock.Clock) {
+			c.Commit()
+			c.Cancel()
+			require.Equal(t, CommandState_CancelPending, c.State())
+
+			c.Done()
+			require.Equal(t, CommandState_Done, c.State())
+
+			c.HandleCancel()
 			require.Equal(t, CommandState_Done, c.State())
 		}},
 		{"Invalid_HandleCancel", func(t *testing.T, c *ScheduleTimerCommand, clock clock.Clock) {

--- a/internal/workflows/expiration.go
+++ b/internal/workflows/expiration.go
@@ -15,6 +15,12 @@ import (
 const (
 	maxIterations = 10
 
+	// maxBatchesPerIteration caps how many batch-removal activity calls run
+	// per timer iteration. Each call removes up to BatchSize (default 100)
+	// instances, so this allows draining up to maxBatchesPerIteration × 100
+	// expired instances per cycle.
+	maxBatchesPerIteration = 100
+
 	UpdateExpirationSignal = "update-expiration"
 )
 
@@ -47,23 +53,36 @@ func ExpireWorkflowInstances(ctx workflow.Context, delay time.Duration) error {
 
 		logger.Info("removing workflow instances", slog.Time("before", before))
 
-		var a *Activities
-		_, err := workflow.ExecuteActivity[any](
-			ctx, workflow.ActivityOptions{
-				Queue: core.QueueSystem,
-				RetryOptions: workflow.RetryOptions{
-					MaxAttempts: 2,
-				},
-			}, a.RemoveWorkflowInstances, before).Get(ctx)
-		if err != nil {
-			if errors.As(err, &backend.ErrNotSupported{}) {
-				logger.Warn("removing workflow instances not supported")
+		// Loop the activity to drain expired instances incrementally. Each
+		// invocation removes up to one batch and gets its own activity lock
+		// timeout window, avoiding the death-spiral where a single call tries
+		// to process the entire backlog and always exceeds the deadline.
+		for batch := 0; batch < maxBatchesPerIteration; batch++ {
+			var a *Activities
+			removed, err := workflow.ExecuteActivity[int](
+				ctx, workflow.ActivityOptions{
+					Queue: core.QueueSystem,
+					RetryOptions: workflow.RetryOptions{
+						MaxAttempts: 2,
+					},
+				}, a.RemoveWorkflowInstances, before).Get(ctx)
+			if err != nil {
+				if errors.As(err, &backend.ErrNotSupported{}) {
+					logger.Warn("removing workflow instances not supported")
+					return nil
+				}
 
-				// Stop execution
-				return nil
+				logger.Error("removing workflow instances",
+					slog.Any("error", err), slog.Int("batch", batch))
+				break
 			}
 
-			logger.Error("removing workflow instances", slog.Any("error", err))
+			logger.Info("removed workflow instances",
+				slog.Int("removed", removed), slog.Int("batch", batch))
+
+			if removed == 0 {
+				break
+			}
 		}
 	}
 
@@ -74,6 +93,6 @@ type Activities struct {
 	Backend backend.Backend
 }
 
-func (a *Activities) RemoveWorkflowInstances(ctx context.Context, before time.Time) error {
+func (a *Activities) RemoveWorkflowInstances(ctx context.Context, before time.Time) (int, error) {
 	return a.Backend.RemoveWorkflowInstances(ctx, backend.RemoveFinishedBefore(before))
 }

--- a/internal/workflows/expiration.go
+++ b/internal/workflows/expiration.go
@@ -83,6 +83,13 @@ func ExpireWorkflowInstances(ctx workflow.Context, delay time.Duration) error {
 			if removed == 0 {
 				break
 			}
+
+			// Yield between batches so task processing can acquire the DB lock.
+			// Without this, continuous DELETE batches on large databases starve
+			// GetWorkflowTask/GetActivityTask.
+			if err := workflow.Sleep(ctx, 20*time.Second); err != nil {
+				break
+			}
 		}
 	}
 


### PR DESCRIPTION
Update the sqlite backend `RemoveWorkflowInstances` to improve performance and fix a couple bugs that prevented correctly deleting all history.

This PR also updates `cancellableCommand` state transitions to handle a panic caused by a command completing while in the `CancelPanding` state.