### PR TITLE
Expose SpanID and TraceID in workflow context

### DIFF
--- a/docs/source/includes/_guide.md
+++ b/docs/source/includes/_guide.md
@@ -658,7 +658,7 @@ go-workflows supports structured logging using Go's `slog` package. `slog.Defaul
 logger := workflow.Logger(ctx)
 ```
 
-For logging in workflows, you can get a logger using `workflow.Logger`. The returned logger instance  already has the workflow instance set as a default field.
+For logging in workflows, you can get a logger using `workflow.Logger`. The returned logger instance already has the workflow instance set as a default field. When tracing is enabled (via `backend.WithTracerProvider`), the logger also automatically includes `trace_id` and `span_id` attributes for trace correlation.
 
 ### Activities
 
@@ -700,7 +700,32 @@ func Workflow(ctx workflow.Context) error {
 	span.End()
 ```
 
-For workflows the usage is a bit different, the tracer needs to be aware of whether the workflow is being replayed or not. You can get a replay-aware racer with `workflow.Tracer(ctx)`.
+For workflows the usage is a bit different, the tracer needs to be aware of whether the workflow is being replayed or not. You can get a replay-aware tracer with `workflow.Tracer(ctx)`.
+
+### Accessing TraceID and SpanID
+
+```go
+func Workflow(ctx workflow.Context) error {
+	// From a span you created
+	ctx, span := workflow.Tracer(ctx).Start(ctx, "my-span")
+	defer span.End()
+
+	sc := span.SpanContext()
+	traceID := sc.TraceID().String()
+	spanID := sc.SpanID().String()
+
+	// Or from the current workflow span
+	currentSpan := workflow.SpanFromContext(ctx)
+	if currentSpan != nil {
+		sc := currentSpan.SpanContext()
+		// Use sc.TraceID(), sc.SpanID() for correlation
+	}
+
+	return nil
+}
+```
+
+You can access the `TraceID` and `SpanID` from any workflow span via the `SpanContext()` method. Use `workflow.SpanFromContext(ctx)` to retrieve the current active span from the workflow context without creating a new one. This is useful for correlating logs with traces or passing trace context to external systems.
 
 ## Context Propagation
 

--- a/internal/log/fields.go
+++ b/internal/log/fields.go
@@ -43,4 +43,7 @@ const (
 
 	TimerModeFrom = NamespaceKey + ".timer.mode.from"
 	TimerModeTo   = NamespaceKey + ".timer.mode.to"
+
+	TraceIDKey = NamespaceKey + ".trace.id"
+	SpanIDKey  = NamespaceKey + ".span.id"
 )

--- a/internal/workflowstate/replaylogger_test.go
+++ b/internal/workflowstate/replaylogger_test.go
@@ -1,13 +1,17 @@
 package workflowstate
 
 import (
+	"bytes"
+	"context"
 	"log/slog"
 	"testing"
 
 	"github.com/benbjohnson/clock"
 	"github.com/cschleiden/go-workflows/core"
+	log "github.com/cschleiden/go-workflows/internal/log"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace/noop"
 )
 
@@ -25,4 +29,44 @@ func Test_ReplayLogger_WithGroup(t *testing.T) {
 
 	with := wfState.Logger().WithGroup("group_name")
 	require.IsType(t, &replayHandler{}, with.Handler())
+}
+
+func Test_UpdateLoggerWithSpan(t *testing.T) {
+	// Use a real tracer so spans have valid TraceID/SpanID
+	tp := sdktrace.NewTracerProvider()
+	tracer := tp.Tracer("test")
+	_, span := tracer.Start(context.Background(), "test-span")
+	sc := span.SpanContext()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	i := core.NewWorkflowInstance(uuid.NewString(), "")
+	wfState := NewWorkflowState(i, logger, tracer, clock.New())
+
+	wfState.UpdateLoggerWithSpan(sc)
+
+	// Log a message and verify it contains trace context
+	wfState.Logger().Info("test message")
+
+	output := buf.String()
+	require.Contains(t, output, log.TraceIDKey)
+	require.Contains(t, output, log.SpanIDKey)
+	require.Contains(t, output, sc.TraceID().String())
+	require.Contains(t, output, sc.SpanID().String())
+}
+
+func Test_UpdateLoggerWithSpan_PreservesReplayHandler(t *testing.T) {
+	tp := sdktrace.NewTracerProvider()
+	tracer := tp.Tracer("test")
+	_, span := tracer.Start(context.Background(), "test-span")
+	sc := span.SpanContext()
+
+	i := core.NewWorkflowInstance(uuid.NewString(), "")
+	wfState := NewWorkflowState(i, slog.Default(), tracer, clock.New())
+
+	wfState.UpdateLoggerWithSpan(sc)
+
+	// The handler should still be a replayHandler after updating
+	require.IsType(t, &replayHandler{}, wfState.Logger().Handler())
 }

--- a/internal/workflowstate/workflowstate.go
+++ b/internal/workflowstate/workflowstate.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cschleiden/go-workflows/backend/payload"
 	"github.com/cschleiden/go-workflows/core"
 	"github.com/cschleiden/go-workflows/internal/command"
+	log "github.com/cschleiden/go-workflows/internal/log"
 	"github.com/cschleiden/go-workflows/internal/sync"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -170,6 +171,15 @@ func (wf *WfState) Instance() *core.WorkflowInstance {
 
 func (wf *WfState) Logger() *slog.Logger {
 	return wf.logger
+}
+
+// UpdateLoggerWithSpan updates the logger to include trace_id and span_id attributes
+// from the given span context.
+func (wf *WfState) UpdateLoggerWithSpan(sc trace.SpanContext) {
+	wf.logger = wf.logger.With(
+		slog.String(log.TraceIDKey, sc.TraceID().String()),
+		slog.String(log.SpanIDKey, sc.SpanID().String()),
+	)
 }
 
 func (wf *WfState) Tracer() trace.Tracer {

--- a/tester/tester_tracing_test.go
+++ b/tester/tester_tracing_test.go
@@ -1,0 +1,58 @@
+package tester
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cschleiden/go-workflows/workflow"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_SpanFromContext(t *testing.T) {
+	var traceIDStr string
+
+	wf := func(ctx workflow.Context) (string, error) {
+		span := workflow.SpanFromContext(ctx)
+		if span != nil {
+			sc := span.SpanContext()
+			traceIDStr = sc.TraceID().String()
+		}
+
+		return traceIDStr, nil
+	}
+
+	tester := NewWorkflowTester[string](wf)
+	tester.Execute(context.Background())
+
+	require.True(t, tester.WorkflowFinished())
+	// With noop tracer, span context has zero values but the API should not panic
+	_, err := tester.WorkflowResult()
+	require.NoError(t, err)
+}
+
+func Test_TracerStartAndSpanContext(t *testing.T) {
+	wf := func(ctx workflow.Context) error {
+		tracer := workflow.Tracer(ctx)
+		ctx, span := tracer.Start(ctx, "test span")
+
+		// Should be able to get SpanContext without panicking
+		sc := span.SpanContext()
+		_ = sc.TraceID()
+		_ = sc.SpanID()
+
+		span.End()
+
+		// SpanFromContext should return the span we just created
+		currentSpan := workflow.SpanFromContext(ctx)
+		require.NotNil(t, currentSpan)
+
+		return nil
+	}
+
+	tester := NewWorkflowTester[any](wf)
+	tester.Execute(context.Background())
+
+	require.True(t, tester.WorkflowFinished())
+	_, err := tester.WorkflowResult()
+	require.NoError(t, err)
+}

--- a/workflow/executor/executor.go
+++ b/workflow/executor/executor.go
@@ -435,6 +435,9 @@ func (e *executor) handleWorkflowExecutionStarted(event *history.Event, a *histo
 	e.workflowCtx = tracing.ContextWithSpan(e.workflowCtx, span)
 	e.workflowSpan = span
 
+	// Update logger with trace context so workflow.Logger includes trace_id and span_id
+	e.workflowState.UpdateLoggerWithSpan(span.SpanContext())
+
 	e.workflow = newWorkflow(reflect.ValueOf(wfFn))
 	return e.workflow.Execute(e.workflowCtx, a.Inputs)
 }

--- a/workflow/tracer.go
+++ b/workflow/tracer.go
@@ -23,14 +23,36 @@ func (s *wfSpan) End() {
 	}
 }
 
+func (s *wfSpan) SpanContext() trace.SpanContext {
+	return s.span.SpanContext()
+}
+
 type Span interface {
 	// End ends the span.
 	End()
+
+	// SpanContext returns the span context of the span, allowing access to
+	// the TraceID and SpanID.
+	SpanContext() trace.SpanContext
 }
 
 // Tracer creates a the workflow tracer.
 func Tracer(ctx Context) *WorkflowTracer {
 	return &WorkflowTracer{}
+}
+
+// SpanFromContext returns the current span from the workflow context.
+// This can be used to access the TraceID and SpanID of the active workflow span.
+func SpanFromContext(ctx Context) Span {
+	span := tracing.SpanFromContext(ctx)
+	if span == nil {
+		return nil
+	}
+
+	return &wfSpan{
+		span:  span,
+		state: workflowstate.WorkflowState(ctx),
+	}
 }
 
 type WorkflowTracer struct {

--- a/workflow/tracer_test.go
+++ b/workflow/tracer_test.go
@@ -1,0 +1,105 @@
+package workflow
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/cschleiden/go-workflows/internal/sync"
+	"github.com/cschleiden/go-workflows/internal/tracing"
+	"github.com/cschleiden/go-workflows/internal/workflowstate"
+
+	"github.com/benbjohnson/clock"
+	"github.com/cschleiden/go-workflows/core"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
+)
+
+func newTestContext(tracer trace.Tracer) (sync.Context, *workflowstate.WfState) {
+	i := core.NewWorkflowInstance(uuid.NewString(), "")
+	wfState := workflowstate.NewWorkflowState(i, slog.Default(), tracer, clock.New())
+
+	ctx := sync.Background()
+	ctx = workflowstate.WithWorkflowState(ctx, wfState)
+	return ctx, wfState
+}
+
+func TestSpanFromContext_NoSpan(t *testing.T) {
+	tracer := noop.NewTracerProvider().Tracer("test")
+	ctx, _ := newTestContext(tracer)
+
+	span := SpanFromContext(ctx)
+	require.Nil(t, span)
+}
+
+func TestSpanFromContext_WithSpan(t *testing.T) {
+	tp := sdktrace.NewTracerProvider()
+	tracer := tp.Tracer("test")
+
+	ctx, _ := newTestContext(tracer)
+
+	// Start a real span and put it in the workflow context
+	_, otelSpan := tracer.Start(context.Background(), "test-span")
+	ctx = tracing.ContextWithSpan(ctx, otelSpan)
+
+	span := SpanFromContext(ctx)
+	require.NotNil(t, span)
+
+	sc := span.SpanContext()
+	require.True(t, sc.TraceID().IsValid())
+	require.True(t, sc.SpanID().IsValid())
+}
+
+func TestSpan_SpanContext(t *testing.T) {
+	tp := sdktrace.NewTracerProvider()
+	tracer := tp.Tracer("test")
+
+	_, wfState := newTestContext(tracer)
+
+	// Create a real span
+	_, otelSpan := tracer.Start(context.Background(), "test-span")
+	expectedSC := otelSpan.SpanContext()
+
+	s := &wfSpan{span: otelSpan, state: wfState}
+
+	// Verify SpanContext() returns the same data
+	sc := s.SpanContext()
+	require.Equal(t, expectedSC.TraceID(), sc.TraceID())
+	require.Equal(t, expectedSC.SpanID(), sc.SpanID())
+
+	// Verify the Span interface is satisfied
+	var _ Span = s
+	require.True(t, sc.TraceID().IsValid())
+	require.True(t, sc.SpanID().IsValid())
+}
+
+func TestSpan_End_NotReplaying(t *testing.T) {
+	tp := sdktrace.NewTracerProvider()
+	tracer := tp.Tracer("test")
+
+	_, wfState := newTestContext(tracer)
+	wfState.SetReplaying(false)
+
+	_, otelSpan := tracer.Start(context.Background(), "test-span")
+	s := &wfSpan{span: otelSpan, state: wfState}
+
+	// Should not panic
+	s.End()
+}
+
+func TestSpan_End_Replaying(t *testing.T) {
+	tp := sdktrace.NewTracerProvider()
+	tracer := tp.Tracer("test")
+
+	_, wfState := newTestContext(tracer)
+	wfState.SetReplaying(true)
+
+	_, otelSpan := tracer.Start(context.Background(), "test-span")
+	s := &wfSpan{span: otelSpan, state: wfState}
+
+	// Should not panic; span.End() should be skipped during replay
+	s.End()
+}


### PR DESCRIPTION
## Problem

Fixes #473 — Users cannot obtain the TraceID and SpanID from within workflow code. After calling `workflow.Tracer(ctx).Start(ctx, "name")`, the returned `Span` only exposes `End()`, making it impossible to access trace context. Additionally, `workflow.Logger(ctx)` doesn't include trace correlation attributes.

## Changes

### 1. `SpanContext()` on `workflow.Span` interface
The `Span` interface now exposes `SpanContext() trace.SpanContext`, allowing users to retrieve TraceID and SpanID:

```go
ctx, span := workflow.Tracer(ctx).Start(ctx, "my operation")
defer span.End()

traceID := span.SpanContext().TraceID()
spanID := span.SpanContext().SpanID()
```

### 2. `workflow.SpanFromContext(ctx)`
New public helper to get the current active span from the workflow context (mirrors OTel's `trace.SpanFromContext`):

```go
span := workflow.SpanFromContext(ctx)
if span != nil {
    traceID := span.SpanContext().TraceID()
}
```

### 3. Trace context in workflow logger
The workflow logger now automatically includes `trace_id` and `span_id` as structured log attributes, so all log entries from `workflow.Logger(ctx)` are correlated with the workflow's trace span.

## Files changed

- `workflow/tracer.go` — Added `SpanContext()` to interface + `SpanFromContext` function
- `internal/log/fields.go` — Added `TraceIDKey` and `SpanIDKey` constants
- `internal/workflowstate/workflowstate.go` — Added `UpdateLoggerWithSpan` method
- `workflow/executor/executor.go` — Call `UpdateLoggerWithSpan` after workflow span creation