### PR TITLE
fix: resolve O(n^3) performance degradation in workflow tester (#377)

### DIFF
--- a/internal/workflowstate/workflowstate.go
+++ b/internal/workflowstate/workflowstate.go
@@ -57,6 +57,7 @@ type WfState struct {
 	instance        *core.WorkflowInstance
 	scheduleEventID int64
 	commands        []command.Command
+	commandIndex    map[int64]command.Command
 	pendingFutures  map[int64]*DecodingSettable
 	replaying       bool
 
@@ -75,6 +76,7 @@ func NewWorkflowState(instance *core.WorkflowInstance, logger *slog.Logger, trac
 	state := &WfState{
 		instance:        instance,
 		commands:        []command.Command{},
+		commandIndex:    make(map[int64]command.Command),
 		scheduleEventID: 1,
 		pendingFutures:  map[int64]*DecodingSettable{},
 
@@ -137,16 +139,11 @@ func (wf *WfState) Commands() []command.Command {
 
 func (wf *WfState) AddCommand(cmd command.Command) {
 	wf.commands = append(wf.commands, cmd)
+	wf.commandIndex[cmd.ID()] = cmd
 }
 
 func (wf *WfState) CommandByScheduleEventID(scheduleEventID int64) command.Command {
-	for _, c := range wf.commands {
-		if c.ID() == scheduleEventID {
-			return c
-		}
-	}
-
-	return nil
+	return wf.commandIndex[scheduleEventID]
 }
 
 func (wf *WfState) SetReplaying(replaying bool) {

--- a/tester/tester.go
+++ b/tester/tester.go
@@ -74,6 +74,7 @@ type testWorkflow struct {
 	metadata      *metadata.WorkflowMetadata
 	history       []*history.Event
 	pendingEvents []*history.Event
+	executor      executor.WorkflowExecutor
 }
 
 type WorkflowTester[TResult any] interface {
@@ -357,29 +358,30 @@ func (wt *workflowTester[TResult]) Execute(ctx context.Context, args ...any) {
 			t := getNextWorkflowTask(tw.instance, tw.history, tw.pendingEvents)
 			tw.pendingEvents = tw.pendingEvents[:0]
 
-			// Execute task
-			e, err := executor.NewExecutor(
-				wt.logger,
-				wt.tracer,
-				wt.registry,
-				wt.converter,
-				wt.propagators,
-				&testHistoryProvider{tw.history},
-				tw.instance,
-				tw.metadata,
-				wt.clock,
-				wt.options.MaxHistorySize,
-			)
-			if err != nil {
-				panic(fmt.Errorf("could not create workflow executor: %v", err))
+			// Reuse cached executor or create a new one
+			if tw.executor == nil {
+				var err error
+				tw.executor, err = executor.NewExecutor(
+					wt.logger,
+					wt.tracer,
+					wt.registry,
+					wt.converter,
+					wt.propagators,
+					&testHistoryProvider{tw.history},
+					tw.instance,
+					tw.metadata,
+					wt.clock,
+					wt.options.MaxHistorySize,
+				)
+				if err != nil {
+					panic(fmt.Errorf("could not create workflow executor: %v", err))
+				}
 			}
 
-			result, err := e.ExecuteTask(ctx, t)
+			result, err := tw.executor.ExecuteTask(ctx, t)
 			if err != nil {
 				panic("Error while executing workflow" + err.Error())
 			}
-
-			e.Close()
 
 			// Add all executed events to history
 			tw.history = append(tw.history, result.Executed...)
@@ -395,6 +397,12 @@ func (wt *workflowTester[TResult]) Execute(ctx context.Context, args ...any) {
 						wt.workflowFinished = true
 						wt.workflowResult = a.Result
 						wt.workflowErr = a.Error
+					}
+
+					// Close cached executor for finished workflow
+					if tw.executor != nil {
+						tw.executor.Close()
+						tw.executor = nil
 					}
 
 				case history.EventType_TimerCanceled:

--- a/tester/tester_bench_test.go
+++ b/tester/tester_bench_test.go
@@ -1,0 +1,49 @@
+package tester
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cschleiden/go-workflows/workflow"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// Reproduces https://github.com/cschleiden/go-workflows/issues/377
+func benchWF(ctx workflow.Context, n int) error {
+	wg := workflow.NewWaitGroup()
+	for range n {
+		wg.Add(1)
+		workflow.Go(ctx, func(ctx workflow.Context) {
+			defer wg.Done()
+			workflow.ExecuteActivity[any](ctx, workflow.DefaultActivityOptions, benchAct).Get(ctx)
+		})
+	}
+	wg.Wait(ctx)
+	return nil
+}
+
+func benchAct(ctx context.Context) error {
+	return nil
+}
+
+func BenchmarkWorkflowGo(b *testing.B) {
+	run := func(b *testing.B, n int) {
+		b.Run("n="+fmt.Sprint(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				wft := NewWorkflowTester[any](benchWF)
+				wft.OnActivity(benchAct, mock.Anything).Return(nil)
+				wft.Execute(context.Background(), n)
+				require.True(b, wft.WorkflowFinished())
+				_, err := wft.WorkflowResult()
+				require.NoError(b, err)
+			}
+		})
+	}
+	run(b, 1)
+	run(b, 32)
+	run(b, 64)
+	run(b, 128)
+	run(b, 256)
+}


### PR DESCRIPTION
Fixes #377

## Problem

The workflow tester exhibits O(n^3) performance degradation when using `workflow.Go` with many concurrent goroutines. A workflow spawning 256 goroutines takes ~71 seconds in the tester vs milliseconds with a real backend.

## Root Cause

Two compounding factors:

1. **Executor recreation on every task** — The tester created a new executor for each workflow task, forcing full history replay. With n activities completing one at a time, this means n replays of growing history (O(n^2) total replay work).

2. **Linear scan in CommandByScheduleEventID** — During replay, each event lookup scans all commands linearly. With O(n) events each scanning O(n) commands, this adds another factor of n, yielding O(n^3) overall.

## Changes

### 1. Cache executor per workflow instance in tester (`tester/tester.go`)

The real worker already caches executors via an LRU cache. The tester now does the same — stores the executor on the `testWorkflow` struct and reuses it across tasks. The executor is closed when the workflow finishes to prevent goroutine leaks.

### 2. O(1) command lookup via index map (`internal/workflowstate/workflowstate.go`)

Added a `commandIndex map[int64]command.Command` alongside the existing slice. `AddCommand` populates both, and `CommandByScheduleEventID` now returns directly from the map instead of scanning the slice.

## Benchmark Results

Using the exact reproduction from #377 (n goroutines, each executing one activity):

| n | Before | After | Speedup | Alloc reduction |
|---|--------|-------|---------|------------------|
| 1 | 1.67ms | 1.66ms | 1x | 1x |
| 32 | 301ms | 15.6ms | **19x** | 20x |
| 64 | 1,268ms | 38.6ms | **33x** | 42x |
| 128 | 8,587ms | 209ms | **41x** | 84x |
| 256 | 70,859ms | 507ms | **140x** | **170x** |

At n=256: 8.5 GB heap allocations reduced to 50 MB per operation (measured via `-benchmem`).

<details>
<summary>Raw benchmark output</summary>

**Before (main):**
```
BenchmarkWorkflowGo/n=1-14            742     1672040 ns/op      34585 B/op      399 allocs/op
BenchmarkWorkflowGo/n=32-14             6   300645967 ns/op   20481288 B/op   253442 allocs/op
BenchmarkWorkflowGo/n=64-14             1  1268183200 ns/op  146344936 B/op  1789189 allocs/op
BenchmarkWorkflowGo/n=128-14            1  8586964900 ns/op 1103860864 B/op 13428877 allocs/op
BenchmarkWorkflowGo/n=256-14            1 70859178000 ns/op 8574337680 B/op 104063008 allocs/op
```

**After (this PR):**
```
BenchmarkWorkflowGo/n=1-14            720     1659500 ns/op      27911 B/op      294 allocs/op
BenchmarkWorkflowGo/n=32-14           100    15586562 ns/op    1006682 B/op    12635 allocs/op
BenchmarkWorkflowGo/n=64-14            32    38609597 ns/op    3522029 B/op    43515 allocs/op
BenchmarkWorkflowGo/n=128-14            9   209144400 ns/op   13125666 B/op   160591 allocs/op
BenchmarkWorkflowGo/n=256-14            2   507286200 ns/op   50688852 B/op   616224 allocs/op
```

</details>

## Remaining O(n^2) behavior

The coroutine scheduler (`internal/sync/scheduler.go`) iterates all coroutines on every `Continue()` call. This is inherent to the cooperative scheduling model and would require a more invasive redesign to address. However, with the cubic factor eliminated, the tester is now practical for real-world use cases (256 goroutines in 500ms vs 71 seconds).

## Testing

- All existing tester tests pass (42 tests)
- All internal package tests pass
- All workflow executor tests pass
- Benchmark included in `tester/tester_bench_test.go`
